### PR TITLE
Implement tensor ops with device-aware allocation

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -11,6 +11,10 @@ All code now lives directly in this repository; **there are no submodules**.
   FlashAttention kernel that is invoked through a monkey‑patch. The backward
   pass and fused dropout are not yet implemented and performance gains only
   appear at long sequence lengths (≥4K tokens).
+- The repository is pivoting toward a **full Metal-native forward and backward
+  pass** for tensor operations. The existing PyTorch bridge remains only for
+  regression tests while we rebuild the stack from scratch to outperform
+  PyTorch on Apple Silicon.
 - See `docs/project_status.md` for a snapshot of ongoing work and next steps.
 
 ## Layout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,14 @@ project(orchard LANGUAGES C CXX OBJCXX)
 
 option(ORCHARD_BUILD_EXPERIMENTAL "Build experimental PyTorch components" OFF)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+find_package(Metal REQUIRED)
+link_libraries(Metal::Metal)
+
+include(CTest)
+
 set(CMAKE_OSX_ARCHITECTURES "arm64;arm64e")
-set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -16,10 +22,6 @@ set(CMAKE_OBJCXX_EXTENSIONS ON)
 add_compile_options(-std=gnu++20 -Wall -Wextra -pedantic)
 add_compile_options($<$<COMPILE_LANGUAGE:OBJCXX>:-fno-objc-arc>)
 add_link_options(-ObjC++)
-
-find_library(METAL Metal REQUIRED)
-find_library(METALKIT MetalKit REQUIRED)
-find_library(FOUNDATION Foundation REQUIRED)
 
 add_subdirectory(metal-tensor)
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ The earlier PyTorch-centric approach is preserved under `experimental/` for
 reference. It contains a forward-only FlashAttention kernel wired in via a
 PyTorch extension and monkey‑patch. The kernel is correct but speedups only
 appear at long sequence lengths and the backward path is still a CPU fallback.
+Work has now pivoted to a **ground‑up Metal tensor stack** where both the
+forward and eventual backward passes are implemented natively for Apple
+Silicon, targeting performance beyond what PyTorch can deliver on this
+hardware.
 
-Development has now pivoted to a ground‑up Metal tensor stack tailored for Mac
-hardware. See `docs/project_status.md` for an overview of current progress and
-the roadmap.
+See `docs/project_status.md` for an overview of current progress and the
+roadmap.
 
 ## Building
 

--- a/cmake/FindMetal.cmake
+++ b/cmake/FindMetal.cmake
@@ -1,0 +1,46 @@
+# FindMetal.cmake - locate Metal frameworks and configure macOS SDK
+
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+    message(FATAL_ERROR "Metal SDK requires macOS and Xcode command line tools.")
+endif()
+
+find_program(METAL_XCRUN xcrun REQUIRED)
+
+# Determine SDK path
+execute_process(
+    COMMAND ${METAL_XCRUN} --sdk macosx --show-sdk-path
+    OUTPUT_VARIABLE METAL_SDK_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _sdk_path_result
+)
+if(NOT _sdk_path_result EQUAL 0 OR METAL_SDK_PATH STREQUAL "")
+    message(FATAL_ERROR "Failed to locate macOS SDK. Install Xcode command line tools.")
+endif()
+set(CMAKE_OSX_SYSROOT "${METAL_SDK_PATH}" CACHE PATH "macOS SDK" FORCE)
+
+# Determine SDK version and derive deployment target
+execute_process(
+    COMMAND ${METAL_XCRUN} --sdk macosx --show-sdk-version
+    OUTPUT_VARIABLE METAL_SDK_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _sdk_ver_result
+)
+if(NOT _sdk_ver_result EQUAL 0)
+    message(FATAL_ERROR "Failed to determine macOS SDK version.")
+endif()
+string(REGEX MATCH "^[0-9]+\.[0-9]+" METAL_DEPLOYMENT_TARGET "${METAL_SDK_VERSION}")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "${METAL_DEPLOYMENT_TARGET}" CACHE STRING "macOS deployment target" FORCE)
+
+# Locate required frameworks
+find_library(Metal_FRAMEWORK Metal REQUIRED)
+find_library(MetalKit_FRAMEWORK MetalKit REQUIRED)
+find_library(Foundation_FRAMEWORK Foundation REQUIRED)
+
+set(Metal_LIBRARIES ${Metal_FRAMEWORK} ${MetalKit_FRAMEWORK} ${Foundation_FRAMEWORK})
+add_library(Metal::Metal INTERFACE IMPORTED)
+set_target_properties(Metal::Metal PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${Metal_LIBRARIES}"
+)
+
+set(Metal_FOUND TRUE)
+

--- a/docs/tensor.md
+++ b/docs/tensor.md
@@ -1,12 +1,28 @@
 # Tensor v0 Overview
 
-`metal-tensor` provides a minimal tensor API backed by Apple Metal. This
-document will grow with the implementation and currently outlines the planned
-features:
+`metal-tensor` provides a minimal tensor API backed by Apple Metal. It is the
+foundation for a fully Metal-native forward and backward pass that aims to
+surpass PyTorch on Apple Silicon. This document will grow with the
+implementation and currently outlines the planned features:
 
 - rank-8 shapes and strides
 - intrusive reference counting
 - zero-copy transfers between CPU and GPU
+
+## Toolchain
+
+Building requires Apple's Xcode command line tools and the Metal SDK.
+
+1. Install the tools with `xcode-select --install`.
+2. Confirm availability: `xcode-select -p` should print a path.
+3. Verify the SDK: `xcrun --sdk macosx --show-sdk-path`.
+4. Configure and build the project:
+   ```bash
+   cmake -S . -B build
+   cmake --build build
+   ```
+   The build scripts automatically align `CMAKE_OSX_SYSROOT` and
+   `CMAKE_OSX_DEPLOYMENT_TARGET` with the detected SDK.
 
 Example usage:
 

--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_library(orchard_core STATIC
   metal/core/core.cpp
+  metal/core/tensor/Tensor.cpp
 )
 
 target_include_directories(orchard_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/metal)
+
+target_link_libraries(orchard_core PUBLIC uuid)
 
 add_library(orchard_metal STATIC
   metal/runtime/runtime.mm
@@ -10,4 +13,8 @@ add_library(orchard_metal STATIC
 
 target_include_directories(orchard_metal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/metal)
 
-target_link_libraries(orchard_metal PUBLIC orchard_core ${METAL} ${METALKIT} ${FOUNDATION})
+target_link_libraries(orchard_metal PUBLIC orchard_core)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/metal-tensor/docs/design_spec_tensor_v0.md
+++ b/metal-tensor/docs/design_spec_tensor_v0.md
@@ -1,0 +1,42 @@
+## Tensor v0 Design Specification
+
+### 1. Repository Layout
+- The project is organized as a mono‑repo where all tensor sources live under `metal-tensor/` and legacy PyTorch code is quarantined in `experimental/`. This makes the tensor stack self‑contained and avoids hidden dependencies on submodules.
+- Static libraries are emitted from this tree: `liborchard_core.a` hosts CPU‑only code and `liborchard_metal.a` contains Metal helpers. Both libraries are built from sources in this directory and exported to any higher‑level consumers.
+
+### 2. Build & Toolchain Requirements
+- CMake ≥ 3.27 configures a C++20 / Objective‑C++20 toolchain with `-std=gnu++20`, `-fno-objc-arc`, and `-ObjC++` flags. These settings guarantee uniform language features and ABI behavior across all targets.
+- Fat binaries for `arm64;arm64e` are produced by default, ensuring the libraries run on every Apple Silicon generation. Developers must install Xcode Command Line Tools and the Metal SDK; the build scripts query `xcrun` to derive the correct SDK paths.
+
+### 3. Tensor API Surface
+- `Tensor.h`, `TensorImpl.h`, `Storage.h`, and `DType.h` form the public ABI. They expose rank‑8 shape/stride arrays, intrusive reference counting, and a `Device` enum covering `cpu` and `mps` backends.
+- Factory methods `empty`, `zerosLike`, and `fromData` are marked `[[nodiscard]]` so callers cannot accidentally drop tensors. Transformations such as `view`, `slice`, `to`, and `contiguous` always return new `Tensor` objects that own their metadata and maintain reference counts correctly.
+
+### 4. Memory Model & Storage Semantics
+- All allocations are 64‑byte aligned. The CPU path uses `posix_memalign` while the Metal path delegates to `MTLBuffer` with `storageModeShared`. For buffers larger than 16 MiB an IOSurface is created and marked purgeable to survive memory pressure on macOS.
+- `Storage` holds a UUID label, a pointer to the owning `Allocator`, and an atomic refcount. Move construction steals the pointer without touching the refcount; cloning allocates a new buffer and copies the contents so mutations never alias unexpectedly.
+
+### 5. Runtime Contexts
+- `CpuContext` wraps Accelerate/BNNS primitives. Each thread lazily constructs its own context and exposes helpers like vector addition so CPU fallback paths are straightforward to implement.
+- `MetalContext` wraps the system default `MTLDevice` and maintains a thread‑local pool of `MTLCommandQueue` objects. Returning queues to the pool amortizes creation costs and keeps GPU dispatch lock‑free.
+
+### 6. Autograd Hooks & Forward/Backward Strategy
+- `TensorImpl` reserves `grad_fn` and `grad_ctx` pointers. They remain `nullptr` in Tensor v0 but define the ABI contract for the upcoming autograd engine. Move and clone operations preserve or reset these hooks as ownership dictates so that gradients can eventually propagate through complex view/slice graphs.
+- The long‑term goal is a **full Metal-native backward pass**. Tensor::backward currently asserts with a clear message, reminding developers that autograd is pending. Once the engine lands, both forward and backward kernels will run on Metal without detouring through PyTorch, unlocking higher throughput on Apple Silicon.
+- The existing FlashAttention forward pass continues to work through `libflash_attn.dylib`. Build scripts for the dylib now include headers from `metal-tensor/`, and a shim converts `orchard::Tensor` to `at::Tensor` during the transition period.
+
+### 7. Validation Matrix & Testing Strategy
+- Unit tests live under `metal-tensor/tests/` and use GoogleTest. They verify zero‑copy `to("cpu")`, slice/view mutation coherence, clone storage independence, data pointer alignment, and allocator stress with 100 k alloc/free cycles.
+- Fuzz tests and race‑condition tests (planned) will exercise random shape/stride transformations and multi‑threaded reference counting. Any imbalance or lock misuse fails the suite to keep concurrency bugs from creeping in.
+
+### 8. Instrumentation & Profiling Hooks
+- When compiled with `ORCHARD_PROFILE_ALLOC`, every allocation logs its UUID, shape, dtype, and device to `/tmp/orchard_tensor_profile.log`. These logs feed directly into Instruments or custom analysis scripts for leak tracking.
+- Each `MTLBuffer` is tagged `tensor-<UUID>` so the Metal Performance HUD and GPU capture tools can correlate GPU memory to tensor metadata. A debugging function `dump_live_tensors()` will enumerate non‑zero refcounts for post‑mortem analysis.
+
+### 9. Documentation & Developer Workflow
+- `docs/tensor.md` describes API usage, memory model diagrams, and profiling instructions. Contributors follow `AGENTS.md` for the canonical build and test workflow, which no longer references submodules.
+- All public headers must compile standalone under `-Wall -Wextra -Wpedantic`, and code is formatted with `clang-format`. Pull requests that fail to run `cmake` and the test suite locally are rejected.
+
+### 10. Roadmap & Deprecation Plan
+- Phase 1 stabilizes Tensor v0, allocator, runtime contexts, and validation tests while keeping the PyTorch bridge behind `ORCHARD_BUILD_EXPERIMENTAL`. Once this phase is complete the forward pass of FlashAttention will be recompiled to consume `orchard::Tensor` directly.
+- Phase 2 adds foundational ops and the autograd engine, enabling full training loops without PyTorch. The legacy bridge will be deprecated and eventually removed once performance parity is demonstrated across macOS 13–15 on Apple M‑series hardware.

--- a/metal-tensor/metal/core/tensor/Storage.h
+++ b/metal-tensor/metal/core/tensor/Storage.h
@@ -3,29 +3,55 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>
+#include <string>
+
+#include <uuid/uuid.h>
 
 #include "DType.h"
+#include "runtime/Allocator.h"
 
 namespace orchard::core::tensor {
 
 struct Storage {
-  void* data{nullptr};
+  void *data{nullptr};
   std::size_t nbytes{0};
   Device device{Device::cpu};
   std::atomic<std::size_t> refcount{1};
+  runtime::Allocator *allocator{nullptr};
+  std::string label;
 
-  static Storage* create(std::size_t bytes, Device dev) {
-    void* ptr = nullptr;
-    if (posix_memalign(&ptr, 64, bytes) != 0) {
-      return nullptr;
+  static Storage *create(std::size_t bytes, Device dev) {
+    static runtime::CpuAllocator cpu_alloc;
+    static runtime::MetalAllocator metal_alloc;
+
+    runtime::Allocator *alloc = &cpu_alloc;
+    if (dev == Device::mps) {
+      alloc = &metal_alloc;
     }
-    return new Storage{ptr, bytes, dev};
+
+    uuid_t id;
+    uuid_generate(id);
+    char uuid_str[37];
+    uuid_unparse(id, uuid_str);
+
+    void *ptr = alloc->allocate(bytes, uuid_str);
+    if (!ptr)
+      return nullptr;
+
+    Storage *st = new Storage;
+    st->data = ptr;
+    st->nbytes = bytes;
+    st->device = dev;
+    st->allocator = alloc;
+    st->label = uuid_str;
+    return st;
   }
 
   void retain() { refcount.fetch_add(1, std::memory_order_relaxed); }
   void release() {
     if (refcount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      free(data);
+      if (allocator)
+        allocator->deallocate(data);
       delete this;
     }
   }

--- a/metal-tensor/metal/core/tensor/Tensor.cpp
+++ b/metal-tensor/metal/core/tensor/Tensor.cpp
@@ -1,0 +1,368 @@
+#include "Tensor.h"
+
+#include <cstring>
+#include <cassert>
+#include <sstream>
+
+namespace orchard::core::tensor {
+
+namespace {
+
+int rank_of(const std::array<std::int64_t, 8> &shape) {
+  int r = 0;
+  for (auto s : shape) {
+    if (s <= 0)
+      break;
+    ++r;
+  }
+  return r;
+}
+
+std::array<std::int64_t, 8>
+contiguous_strides(const std::array<std::int64_t, 8> &shape) {
+  std::array<std::int64_t, 8> strides{};
+  int r = rank_of(shape);
+  std::int64_t stride = 1;
+  for (int i = r - 1; i >= 0; --i) {
+    strides[i] = stride;
+    stride *= shape[i];
+  }
+  return strides;
+}
+
+std::int64_t numel(const std::array<std::int64_t, 8> &shape) {
+  int r = rank_of(shape);
+  std::int64_t n = 1;
+  for (int i = 0; i < r; ++i)
+    n *= shape[i];
+  return n;
+}
+
+} // namespace
+
+Tensor::Tensor(const Tensor &other) {
+  if (other.impl_) {
+    impl_ = new TensorImpl(*other.impl_);
+    if (impl_->storage) {
+      os_unfair_lock_lock(&other.impl_->lock);
+      impl_->storage->retain();
+      os_unfair_lock_unlock(&other.impl_->lock);
+    }
+  }
+}
+
+Tensor &Tensor::operator=(const Tensor &other) {
+  if (this == &other)
+    return *this;
+  if (impl_) {
+    if (impl_->storage) {
+      os_unfair_lock_lock(&impl_->lock);
+      impl_->storage->release();
+      os_unfair_lock_unlock(&impl_->lock);
+    }
+    delete impl_;
+  }
+  impl_ = nullptr;
+  if (other.impl_) {
+    impl_ = new TensorImpl(*other.impl_);
+    if (impl_->storage) {
+      os_unfair_lock_lock(&other.impl_->lock);
+      impl_->storage->retain();
+      os_unfair_lock_unlock(&other.impl_->lock);
+    }
+  }
+  return *this;
+}
+
+Tensor::Tensor(Tensor &&other) noexcept : impl_(other.impl_) {
+  other.impl_ = nullptr;
+}
+
+Tensor &Tensor::operator=(Tensor &&other) noexcept {
+  if (this != &other) {
+    if (impl_ && impl_->storage) {
+      os_unfair_lock_lock(&impl_->lock);
+      impl_->storage->release();
+      os_unfair_lock_unlock(&impl_->lock);
+      delete impl_;
+    }
+    impl_ = other.impl_;
+    other.impl_ = nullptr;
+  }
+  return *this;
+}
+
+Tensor::~Tensor() {
+  if (impl_) {
+    if (impl_->storage) {
+      os_unfair_lock_lock(&impl_->lock);
+      impl_->storage->release();
+      os_unfair_lock_unlock(&impl_->lock);
+    }
+    delete impl_;
+  }
+}
+
+Tensor Tensor::empty(const std::array<std::int64_t, 8> &shape, DType dtype,
+                     Device dev) {
+  int r = rank_of(shape);
+  if (r > 8)
+    return Tensor{};
+  std::int64_t n = numel(shape);
+  std::size_t bytes = n * dtype_size(dtype);
+  Storage *storage = Storage::create(bytes, dev);
+  if (!storage)
+    return Tensor{};
+  auto *impl = new TensorImpl{};
+  impl->storage = storage;
+  impl->shape = shape;
+  impl->strides = contiguous_strides(shape);
+  impl->dtype = dtype;
+  impl->device = dev;
+  impl->offset = 0;
+  return Tensor(impl);
+}
+
+Tensor Tensor::zerosLike(const Tensor &other) {
+  Tensor t = empty(other.shape(), other.dtype(), other.device());
+  if (t.impl_ && t.impl_->storage) {
+    std::memset(t.impl_->storage->data, 0, t.impl_->storage->nbytes);
+  }
+  return t;
+}
+
+Tensor Tensor::fromData(const void *data,
+                        const std::array<std::int64_t, 8> &shape,
+                        DType dtype, Device dev) {
+  Tensor t = empty(shape, dtype, dev);
+  if (t.impl_ && t.impl_->storage && data) {
+    std::memcpy(t.impl_->storage->data, data, t.impl_->storage->nbytes);
+  }
+  return t;
+}
+
+Tensor Tensor::view(const std::array<std::int64_t, 8> &newShape) const {
+  int r = rank_of(newShape);
+  if (r > 8 || !impl_ || !impl_->storage)
+    return Tensor{};
+  if (numel(newShape) != numel(impl_->shape))
+    return Tensor{};
+  auto *impl = new TensorImpl{};
+  os_unfair_lock_lock(&this->impl_->lock);
+  this->impl_->storage->retain();
+  os_unfair_lock_unlock(&this->impl_->lock);
+  impl->storage = this->impl_->storage;
+  impl->dtype = this->impl_->dtype;
+  impl->device = this->impl_->device;
+  impl->shape = newShape;
+  impl->strides = contiguous_strides(newShape);
+  impl->offset = this->impl_->offset;
+  return Tensor(impl);
+}
+
+Tensor Tensor::slice(int dim, int start, int end, int step) const {
+  if (!impl_ || !impl_->storage)
+    return Tensor{};
+  int r = rank_of(impl_->shape);
+  if (dim < 0 || dim >= r || step <= 0)
+    return Tensor{};
+  if (start < 0 || end > impl_->shape[dim] || start >= end)
+    return Tensor{};
+
+  auto newShape = impl_->shape;
+  auto newStrides = impl_->strides;
+  std::int64_t len = (end - start + step - 1) / step;
+  newShape[dim] = len;
+  newStrides[dim] *= step;
+
+  auto *impl = new TensorImpl{};
+  os_unfair_lock_lock(&this->impl_->lock);
+  this->impl_->storage->retain();
+  os_unfair_lock_unlock(&this->impl_->lock);
+  impl->storage = this->impl_->storage;
+  impl->dtype = this->impl_->dtype;
+  impl->device = this->impl_->device;
+  impl->shape = newShape;
+  impl->strides = newStrides;
+  impl->offset = this->impl_->offset + start * this->impl_->strides[dim];
+  return Tensor(impl);
+}
+
+Tensor Tensor::to(Device dev) const {
+  if (!impl_ || !impl_->storage)
+    return Tensor{};
+  if (dev == impl_->device) {
+    auto *impl = new TensorImpl{};
+    os_unfair_lock_lock(&this->impl_->lock);
+    this->impl_->storage->retain();
+    os_unfair_lock_unlock(&this->impl_->lock);
+    impl->storage = this->impl_->storage;
+    impl->dtype = this->impl_->dtype;
+    impl->device = this->impl_->device;
+    impl->shape = this->impl_->shape;
+    impl->strides = this->impl_->strides;
+    impl->offset = this->impl_->offset;
+    return Tensor(impl);
+  }
+
+  Tensor t = empty(impl_->shape, impl_->dtype, dev);
+  if (t.impl_ && t.impl_->storage) {
+    Tensor src = contiguous();
+    if (src.impl_ && src.impl_->storage) {
+      std::memcpy(t.impl_->storage->data, src.data_ptr(),
+                  t.impl_->storage->nbytes);
+    }
+  }
+  return t;
+}
+
+Tensor Tensor::contiguous() const {
+  if (!impl_ || !impl_->storage)
+    return Tensor{};
+  if (is_contiguous()) {
+    auto *impl = new TensorImpl{};
+    os_unfair_lock_lock(&this->impl_->lock);
+    this->impl_->storage->retain();
+    os_unfair_lock_unlock(&this->impl_->lock);
+    impl->storage = this->impl_->storage;
+    impl->dtype = this->impl_->dtype;
+    impl->device = this->impl_->device;
+    impl->shape = this->impl_->shape;
+    impl->strides = this->impl_->strides;
+    impl->offset = this->impl_->offset;
+    return Tensor(impl);
+  }
+
+  Tensor out = empty(impl_->shape, impl_->dtype, impl_->device);
+  int r = rank_of(impl_->shape);
+  std::array<std::int64_t, 8> dstStrides = contiguous_strides(impl_->shape);
+  std::size_t esize = dtype_size(impl_->dtype);
+
+  const char *src = static_cast<const char *>(impl_->storage->data);
+  char *dst = static_cast<char *>(out.impl_->storage->data);
+  std::array<std::int64_t, 8> idx{};
+  for (std::int64_t i0 = 0; i0 < (r > 0 ? impl_->shape[0] : 1); ++i0) {
+    idx[0] = i0;
+    for (std::int64_t i1 = 0; i1 < (r > 1 ? impl_->shape[1] : 1); ++i1) {
+      idx[1] = i1;
+      for (std::int64_t i2 = 0; i2 < (r > 2 ? impl_->shape[2] : 1); ++i2) {
+        idx[2] = i2;
+        for (std::int64_t i3 = 0; i3 < (r > 3 ? impl_->shape[3] : 1); ++i3) {
+          idx[3] = i3;
+          for (std::int64_t i4 = 0; i4 < (r > 4 ? impl_->shape[4] : 1); ++i4) {
+            idx[4] = i4;
+            for (std::int64_t i5 = 0; i5 < (r > 5 ? impl_->shape[5] : 1);
+                 ++i5) {
+              idx[5] = i5;
+              for (std::int64_t i6 = 0; i6 < (r > 6 ? impl_->shape[6] : 1);
+                   ++i6) {
+                idx[6] = i6;
+                for (std::int64_t i7 = 0; i7 < (r > 7 ? impl_->shape[7] : 1);
+                     ++i7) {
+                  idx[7] = i7;
+                  std::int64_t srcOff = impl_->offset;
+                  std::int64_t dstOff = 0;
+                  for (int d = 0; d < r; ++d) {
+                    srcOff += idx[d] * impl_->strides[d];
+                    dstOff += idx[d] * dstStrides[d];
+                  }
+                  std::memcpy(dst + dstOff * esize, src + srcOff * esize,
+                              esize);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+bool Tensor::is_contiguous() const {
+  if (!impl_)
+    return true;
+  std::array<std::int64_t, 8> expected = contiguous_strides(impl_->shape);
+  int r = rank_of(impl_->shape);
+  for (int i = 0; i < r; ++i) {
+    if (impl_->strides[i] != expected[i])
+      return false;
+  }
+  return true;
+}
+
+Tensor Tensor::clone() const {
+  if (!impl_ || !impl_->storage)
+    return Tensor{};
+  Tensor out = empty(impl_->shape, impl_->dtype, impl_->device);
+  int r = rank_of(impl_->shape);
+  std::array<std::int64_t, 8> dstStrides = contiguous_strides(impl_->shape);
+  std::size_t esize = dtype_size(impl_->dtype);
+  const char *src = static_cast<const char *>(impl_->storage->data);
+  char *dst = static_cast<char *>(out.impl_->storage->data);
+  std::array<std::int64_t, 8> idx{};
+  for (std::int64_t i0 = 0; i0 < (r > 0 ? impl_->shape[0] : 1); ++i0) {
+    idx[0] = i0;
+    for (std::int64_t i1 = 0; i1 < (r > 1 ? impl_->shape[1] : 1); ++i1) {
+      idx[1] = i1;
+      for (std::int64_t i2 = 0; i2 < (r > 2 ? impl_->shape[2] : 1); ++i2) {
+        idx[2] = i2;
+        for (std::int64_t i3 = 0; i3 < (r > 3 ? impl_->shape[3] : 1); ++i3) {
+          idx[3] = i3;
+          for (std::int64_t i4 = 0; i4 < (r > 4 ? impl_->shape[4] : 1); ++i4) {
+            idx[4] = i4;
+            for (std::int64_t i5 = 0; i5 < (r > 5 ? impl_->shape[5] : 1);
+                 ++i5) {
+              idx[5] = i5;
+              for (std::int64_t i6 = 0; i6 < (r > 6 ? impl_->shape[6] : 1);
+                   ++i6) {
+                idx[6] = i6;
+                for (std::int64_t i7 = 0; i7 < (r > 7 ? impl_->shape[7] : 1);
+                     ++i7) {
+                  idx[7] = i7;
+                  std::int64_t srcOff = impl_->offset;
+                  std::int64_t dstOff = 0;
+                  for (int d = 0; d < r; ++d) {
+                    srcOff += idx[d] * impl_->strides[d];
+                    dstOff += idx[d] * dstStrides[d];
+                  }
+                  std::memcpy(dst + dstOff * esize, src + srcOff * esize,
+                              esize);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+std::string Tensor::toString() const {
+  if (!impl_)
+    return "Tensor()";
+  std::ostringstream oss;
+  oss << "Tensor(dtype=" << static_cast<int>(impl_->dtype)
+      << ", device=" << device_name(impl_->device) << ", shape=[";
+  int r = rank_of(impl_->shape);
+  for (int i = 0; i < r; ++i) {
+    if (i)
+      oss << ", ";
+    oss << impl_->shape[i];
+  }
+  oss << "], strides=[";
+  for (int i = 0; i < r; ++i) {
+    if (i)
+      oss << ", ";
+    oss << impl_->strides[i];
+  }
+  oss << "])";
+  return oss.str();
+}
+
+void Tensor::backward() const {
+  assert(!"Tensor::backward() not implemented; autograd engine pending");
+}
+
+} // namespace orchard::core::tensor

--- a/metal-tensor/metal/core/tensor/Tensor.h
+++ b/metal-tensor/metal/core/tensor/Tensor.h
@@ -10,26 +10,45 @@ namespace orchard::core::tensor {
 class Tensor {
 public:
   Tensor() = default;
-  explicit Tensor(TensorImpl* impl) : impl_(impl) {}
+  explicit Tensor(TensorImpl *impl) : impl_(impl) {}
 
-  [[nodiscard]] static Tensor empty(const std::array<std::int64_t,8>& shape,
+  Tensor(const Tensor &other);
+  Tensor &operator=(const Tensor &other);
+  Tensor(Tensor &&other) noexcept;
+  Tensor &operator=(Tensor &&other) noexcept;
+  ~Tensor();
+
+  [[nodiscard]] static Tensor empty(const std::array<std::int64_t, 8> &shape,
                                     DType dtype, Device dev);
-  [[nodiscard]] static Tensor zerosLike(const Tensor& other);
-  [[nodiscard]] Tensor view(const std::array<std::int64_t,8>& newShape) const;
+  [[nodiscard]] static Tensor zerosLike(const Tensor &other);
+  [[nodiscard]] static Tensor fromData(const void *data,
+                                      const std::array<std::int64_t, 8> &shape,
+                                      DType dtype, Device dev);
+  [[nodiscard]] Tensor view(const std::array<std::int64_t, 8> &newShape) const;
   [[nodiscard]] Tensor slice(int dim, int start, int end, int step = 1) const;
   [[nodiscard]] Tensor to(Device dev) const;
   [[nodiscard]] Tensor contiguous() const;
+  void *data_ptr() const {
+    if (!impl_ || !impl_->storage)
+      return nullptr;
+    auto *base = static_cast<char *>(impl_->storage->data);
+    return base + impl_->offset * dtype_size(impl_->dtype);
+  }
+  [[nodiscard]] Tensor clone() const;
 
   DType dtype() const { return impl_->dtype; }
   Device device() const { return impl_->device; }
-  const std::array<std::int64_t,8>& shape() const { return impl_->shape; }
-  const std::array<std::int64_t,8>& strides() const { return impl_->strides; }
-  std::size_t nbytes() const { return impl_->storage ? impl_->storage->nbytes : 0; }
+  const std::array<std::int64_t, 8> &shape() const { return impl_->shape; }
+  const std::array<std::int64_t, 8> &strides() const { return impl_->strides; }
+  std::size_t nbytes() const {
+    return impl_->storage ? impl_->storage->nbytes : 0;
+  }
   bool is_contiguous() const;
   std::string toString() const;
+  void backward() const;
 
 private:
-  TensorImpl* impl_{nullptr};
+  TensorImpl *impl_{nullptr};
 };
 
 } // namespace orchard::core::tensor

--- a/metal-tensor/metal/core/tensor/TensorImpl.h
+++ b/metal-tensor/metal/core/tensor/TensorImpl.h
@@ -9,14 +9,15 @@
 namespace orchard::core::tensor {
 
 struct TensorImpl {
-  Storage* storage{nullptr};
-  std::array<std::int64_t,8> shape{};
-  std::array<std::int64_t,8> strides{};
+  Storage *storage{nullptr};
+  std::array<std::int64_t, 8> shape{};
+  std::array<std::int64_t, 8> strides{};
   DType dtype{DType::f32};
   Device device{Device::cpu};
+  std::int64_t offset{0};
   os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
-  void* grad_fn{nullptr};
-  void* grad_ctx{nullptr};
+  void *grad_fn{nullptr};
+  void *grad_ctx{nullptr};
 };
 
 } // namespace orchard::core::tensor

--- a/metal-tensor/metal/runtime/Allocator.h
+++ b/metal-tensor/metal/runtime/Allocator.h
@@ -2,24 +2,102 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <string>
+
+#ifdef __APPLE__
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#import <IOSurface/IOSurface.h>
+#import <Metal/Metal.h>
+#endif
+#endif
 
 namespace orchard::runtime {
 
 class Allocator {
 public:
   virtual ~Allocator() = default;
-  virtual void* allocate(std::size_t bytes) = 0;
-  virtual void deallocate(void* ptr) = 0;
+  virtual void *allocate(std::size_t bytes, const char *label) = 0;
+  virtual void deallocate(void *ptr) = 0;
 };
 
 class CpuAllocator : public Allocator {
 public:
-  void* allocate(std::size_t bytes) override {
-    void* p = nullptr;
+  void *allocate(std::size_t bytes, const char * /*label*/) override {
+    void *p = nullptr;
     posix_memalign(&p, 64, bytes);
     return p;
   }
-  void deallocate(void* ptr) override { free(ptr); }
+  void deallocate(void *ptr) override { free(ptr); }
 };
 
+class MetalAllocator : public Allocator {
+public:
+  MetalAllocator();
+  void *allocate(std::size_t bytes, const char *label) override;
+  void deallocate(void *ptr) override;
+
+private:
+#ifdef __OBJC__
+  id<MTLDevice> device_{nil};
+#endif
+};
+
+inline MetalAllocator::MetalAllocator() {
+#ifdef __OBJC__
+  device_ = MTLCreateSystemDefaultDevice();
+#endif
+}
+
+inline void *MetalAllocator::allocate(std::size_t bytes, const char *label) {
+#ifdef __OBJC__
+  id<MTLBuffer> buffer = nil;
+  if (bytes > (16 << 20)) {
+    const void *keys[] = {(const void *)kIOSurfaceWidth,
+                          (const void *)kIOSurfaceHeight,
+                          (const void *)kIOSurfaceBytesPerElement};
+    int width = bytes;
+    int height = 1;
+    int bpe = 1;
+    const void *values[] = {
+        CFNumberCreate(nullptr, kCFNumberSInt32Type, &width),
+        CFNumberCreate(nullptr, kCFNumberSInt32Type, &height),
+        CFNumberCreate(nullptr, kCFNumberSInt32Type, &bpe),
+    };
+    CFDictionaryRef dict = CFDictionaryCreate(nullptr, keys, values, 3,
+                                              &kCFTypeDictionaryKeyCallBacks,
+                                              &kCFTypeDictionaryValueCallBacks);
+    IOSurfaceRef surface = IOSurfaceCreate(dict);
+    for (int i = 0; i < 3; ++i)
+      CFRelease(values[i]);
+    CFRelease(dict);
+    buffer = [device_ newBufferWithIOSurface:surface
+                                     options:MTLResourceStorageModeShared
+                                      offset:0
+                                      length:bytes];
+    [buffer setPurgeableState:MTLPurgeableStateKeepCurrent];
+    CFRelease(surface);
+  } else {
+    buffer = [device_ newBufferWithLength:bytes
+                                  options:MTLResourceStorageModeShared];
+  }
+  buffer.label = [[NSString alloc] initWithUTF8String:label];
+  return (__bridge_retained void *)buffer;
+#else
+  (void)bytes;
+  (void)label;
+  return nullptr;
+#endif
+}
+
+inline void MetalAllocator::deallocate(void *ptr) {
+#ifdef __OBJC__
+  id<MTLBuffer> buffer = (__bridge_transfer id<MTLBuffer>)ptr;
+  buffer = nil;
+#else
+  (void)ptr;
+#endif
+}
+
 } // namespace orchard::runtime
+

--- a/metal-tensor/metal/runtime/CpuContext.h
+++ b/metal-tensor/metal/runtime/CpuContext.h
@@ -1,10 +1,41 @@
 #pragma once
 
+#include <cstddef>
+
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#endif
+
 namespace orchard::runtime {
 
+/// Lightweight wrapper around Accelerate/BNNS utilities for CPU‑side ops.
 class CpuContext {
 public:
   CpuContext() = default;
+
+  /// Elementwise vector addition using Accelerate when available.
+  void add(const float *a, const float *b, float *c, std::size_t n) const;
 };
 
+/// Obtain the CPU context associated with the calling thread.
+CpuContext &cpu_context();
+
 } // namespace orchard::runtime
+
+// Inline implementation
+inline void orchard::runtime::CpuContext::add(const float *a, const float *b,
+                                              float *c, std::size_t n) const {
+#ifdef __APPLE__
+  vDSP_vadd(a, 1, b, 1, c, 1, n);
+#else
+  for (std::size_t i = 0; i < n; ++i) {
+    c[i] = a[i] + b[i];
+  }
+#endif
+}
+
+inline orchard::runtime::CpuContext &orchard::runtime::cpu_context() {
+  thread_local CpuContext ctx;
+  return ctx;
+}
+

--- a/metal-tensor/metal/runtime/MetalContext.h
+++ b/metal-tensor/metal/runtime/MetalContext.h
@@ -1,4 +1,12 @@
+// MetalContext.h
+// -------------------------------------------------------------
+// Thin wrapper around the system default Metal device. Each thread
+// receives its own context instance which keeps a pool of command
+// queues for reuse.
+
 #pragma once
+
+#include <vector>
 
 #ifdef __APPLE__
 #include <Metal/Metal.h>
@@ -8,7 +16,64 @@ namespace orchard::runtime {
 
 class MetalContext {
 public:
-  MetalContext() = default;
+  MetalContext();
+
+#ifdef __APPLE__
+  /// Returns the underlying MTLDevice.
+  id<MTLDevice> device() const { return device_; }
+
+  /// Acquire a command queue for the current thread.
+  id<MTLCommandQueue> acquire_command_queue();
+
+  /// Return a command queue to the thread‑local pool.
+  void return_command_queue(id<MTLCommandQueue> queue);
+#endif
+
+private:
+#ifdef __APPLE__
+  id<MTLDevice> device_ = nil;
+  std::vector<id<MTLCommandQueue>> queue_pool_;
+#endif
 };
 
+/// Obtain the Metal context associated with the calling thread.
+MetalContext &metal_context();
+
 } // namespace orchard::runtime
+
+// Inline implementations
+inline orchard::runtime::MetalContext::MetalContext() {
+#ifdef __APPLE__
+  device_ = MTLCreateSystemDefaultDevice();
+#endif
+}
+
+inline id<MTLCommandQueue>
+orchard::runtime::MetalContext::acquire_command_queue() {
+#ifdef __APPLE__
+  if (!queue_pool_.empty()) {
+    id<MTLCommandQueue> queue = queue_pool_.back();
+    queue_pool_.pop_back();
+    return queue;
+  }
+  return [device_ newCommandQueue];
+#else
+  return nullptr;
+#endif
+}
+
+inline void orchard::runtime::MetalContext::return_command_queue(
+    id<MTLCommandQueue> queue) {
+#ifdef __APPLE__
+  if (queue)
+    queue_pool_.push_back(queue);
+#else
+  (void)queue;
+#endif
+}
+
+inline orchard::runtime::MetalContext &orchard::runtime::metal_context() {
+  thread_local MetalContext ctx;
+  return ctx;
+}
+

--- a/metal-tensor/metal/runtime/runtime.mm
+++ b/metal-tensor/metal/runtime/runtime.mm
@@ -1,2 +1,41 @@
+#include "runtime/CpuContext.h"
 #include "runtime/MetalContext.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace orchard::runtime {
+
+using ContextFactory = void *(*)();
+
+namespace {
+
+// Simple registry mapping device names to context factories.
+std::unordered_map<std::string, ContextFactory> &registry() {
+  static std::unordered_map<std::string, ContextFactory> instance;
+  return instance;
+}
+
+} // namespace
+
+void register_device(const std::string &name, ContextFactory factory) {
+  registry()[name] = factory;
+}
+
+void *get_device(const std::string &name) {
+  auto it = registry().find(name);
+  if (it == registry().end()) {
+    return nullptr;
+  }
+  return it->second();
+}
+
+void register_runtime_devices() {
+  register_device("metal", []() -> void * { return &metal_context(); });
+  register_device("cpu", []() -> void * { return &cpu_context(); });
+}
+
+} // namespace orchard::runtime
+
 int runtime_stub() { return 0; }
+

--- a/metal-tensor/tests/CMakeLists.txt
+++ b/metal-tensor/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(metal_tensor_tests tensor_tests.cpp)
+
+target_link_libraries(metal_tensor_tests PRIVATE gtest_main orchard_core orchard_metal)
+
+target_compile_features(metal_tensor_tests PRIVATE cxx_std_20)
+
+add_test(NAME metal_tensor_tests COMMAND metal_tensor_tests)
+

--- a/metal-tensor/tests/tensor_tests.cpp
+++ b/metal-tensor/tests/tensor_tests.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+#include "core/tensor/Tensor.h"
+#include "runtime/Allocator.h"
+
+using namespace orchard::core::tensor;
+
+TEST(TensorTest, ToCpuZeroCopy) {
+  std::array<std::int64_t, 8> shape{4, 1, 1, 1, 1, 1, 1, 1};
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  Tensor cpu = t.to(Device::cpu);
+  EXPECT_EQ(t.data_ptr(), cpu.data_ptr());
+}
+
+TEST(TensorTest, ViewSliceMutation) {
+  std::array<std::int64_t, 8> shape{4, 1, 1, 1, 1, 1, 1, 1};
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *base = static_cast<float *>(t.data_ptr());
+  for (int i = 0; i < 4; ++i)
+    base[i] = static_cast<float>(i);
+
+  std::array<std::int64_t, 8> newShape{2, 2, 1, 1, 1, 1, 1, 1};
+  Tensor v = t.view(newShape);
+  auto *vptr = static_cast<float *>(v.data_ptr());
+  vptr[1] = 42.0f;
+  EXPECT_EQ(base[1], 42.0f);
+
+  Tensor s = t.slice(0, 0, 2);
+  auto *sptr = static_cast<float *>(s.data_ptr());
+  sptr[1] = 99.0f;
+  EXPECT_EQ(base[1], 99.0f);
+}
+
+TEST(TensorTest, CloneDistinctStorage) {
+  std::array<std::int64_t, 8> shape{2, 1, 1, 1, 1, 1, 1, 1};
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *base = static_cast<float *>(t.data_ptr());
+  base[0] = 1.0f;
+  base[1] = 2.0f;
+  Tensor c = t.clone();
+  EXPECT_NE(c.data_ptr(), t.data_ptr());
+  auto *cptr = static_cast<float *>(c.data_ptr());
+  EXPECT_EQ(cptr[0], base[0]);
+  base[0] = 3.0f;
+  EXPECT_NE(cptr[0], base[0]);
+}
+
+TEST(TensorTest, FromDataCopiesInput) {
+  std::array<std::int64_t, 8> shape{2, 1, 1, 1, 1, 1, 1, 1};
+  float src[2] = {1.0f, 2.0f};
+  Tensor t = Tensor::fromData(src, shape, DType::f32, Device::cpu);
+  auto *ptr = static_cast<float *>(t.data_ptr());
+  EXPECT_EQ(ptr[0], 1.0f);
+  src[0] = 3.0f;
+  EXPECT_NE(ptr[0], src[0]);
+}
+
+TEST(TensorTest, DataPtrAlignment) {
+  std::array<std::int64_t, 8> shape{1, 1, 1, 1, 1, 1, 1, 1};
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  std::uintptr_t addr = reinterpret_cast<std::uintptr_t>(t.data_ptr());
+  EXPECT_EQ(addr % 64, 0u);
+}
+
+TEST(AllocatorTest, ArenaStress) {
+  orchard::runtime::CpuAllocator alloc;
+  for (int i = 0; i < 100000; ++i) {
+    void *p = alloc.allocate(64, "stress");
+    alloc.deallocate(p);
+  }
+  SUCCEED();
+}


### PR DESCRIPTION
## Summary
- add Metal toolchain detection and link frameworks globally
- extend Tensor with data access, cloning, and offset-aware view/slice operations
- integrate GoogleTest-based tensor tests, document toolchain, and expand design spec
- stub out Tensor::backward and clarify Metal-native rewrite in docs

## Testing
- `cmake -S . -B build` *(fails: The Objective-C++ compiler is not able to compile a simple test program)*
- `cmake --build build` *(fails: Makefile: No such file or directory)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d8bcb228832e8e243c7c28578ad7