### PR TITLE
Isolate autograd nodes and refine CPU fallbacks

### DIFF
--- a/metal-tensor/metal/core/autograd/MatmulBackward.cpp
+++ b/metal-tensor/metal/core/autograd/MatmulBackward.cpp
@@ -12,23 +12,26 @@ MatmulBackward::MatmulBackward(const Tensor &aa, const Tensor &bb)
 
 void MatmulBackward::apply(Tensor &g) {
   auto m = a.shape()[0];
-  auto k = a.shape()[1];
   auto n = b.shape()[1];
-  Tensor ga = Tensor::empty(a.shape(), DType::f32, g.device());
-  Tensor gb = Tensor::empty(b.shape(), DType::f32, g.device());
-  if (g.device() == Device::mps) {
+  auto k = a.shape()[1];
+  Device dev = g.device();
+  Tensor ga = Tensor::empty(a.shape(), DType::f32, dev);
+  Tensor gb = Tensor::empty(b.shape(), DType::f32, dev);
+  Tensor aa = a.to(dev);
+  Tensor bb = b.to(dev);
+  if (dev == Device::mps) {
     runtime::metal_matmul_backward_a(static_cast<const float *>(g.data_ptr()),
-                                     static_cast<const float *>(b.data_ptr()),
+                                     static_cast<const float *>(bb.data_ptr()),
                                      static_cast<float *>(ga.data_ptr()), m, n,
                                      k);
     runtime::metal_matmul_backward_b(static_cast<const float *>(g.data_ptr()),
-                                     static_cast<const float *>(a.data_ptr()),
+                                     static_cast<const float *>(aa.data_ptr()),
                                      static_cast<float *>(gb.data_ptr()), m, n,
                                      k);
   } else {
-    auto *gp = static_cast<const float *>(g.data_ptr());
-    auto *bp = static_cast<const float *>(b.data_ptr());
-    auto *ap = static_cast<const float *>(a.data_ptr());
+    const auto *gp = static_cast<const float *>(g.data_ptr());
+    const auto *bp = static_cast<const float *>(bb.data_ptr());
+    const auto *ap = static_cast<const float *>(aa.data_ptr());
     auto *gap = static_cast<float *>(ga.data_ptr());
     auto *gbp = static_cast<float *>(gb.data_ptr());
     for (std::size_t i = 0; i < static_cast<std::size_t>(m); ++i) {

--- a/metal-tensor/metal/core/autograd/MeanBackward.cpp
+++ b/metal-tensor/metal/core/autograd/MeanBackward.cpp
@@ -11,7 +11,8 @@ MeanBackward::MeanBackward(const Tensor &aa) : a(aa) {}
 
 void MeanBackward::apply(Tensor &g) {
   Tensor grad = Tensor::empty(a.shape(), DType::f32, g.device());
-  float v = *static_cast<float *>(g.to(Device::cpu).data_ptr());
+  Tensor g_cpu = g.to(Device::cpu);
+  float v = *static_cast<float *>(g_cpu.data_ptr());
   v /= static_cast<float>(a.numel());
   if (g.device() == Device::mps) {
     runtime::metal_fill(static_cast<float *>(grad.data_ptr()), v, a.numel());

--- a/metal-tensor/metal/core/autograd/SumBackward.cpp
+++ b/metal-tensor/metal/core/autograd/SumBackward.cpp
@@ -11,7 +11,8 @@ SumBackward::SumBackward(const Tensor &aa) : a(aa) {}
 
 void SumBackward::apply(Tensor &g) {
   Tensor grad = Tensor::empty(a.shape(), DType::f32, g.device());
-  float v = *static_cast<float *>(g.to(Device::cpu).data_ptr());
+  Tensor g_cpu = g.to(Device::cpu);
+  float v = *static_cast<float *>(g_cpu.data_ptr());
   if (g.device() == Device::mps) {
     runtime::metal_fill(static_cast<float *>(grad.data_ptr()), v, a.numel());
   } else {

--- a/metal-tensor/metal/runtime/MetalKernels.h
+++ b/metal-tensor/metal/runtime/MetalKernels.h
@@ -8,6 +8,7 @@ void metal_mul(const float *a, const float *b, float *c, std::size_t n);
 void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
                   std::size_t n, std::size_t k);
 void metal_reduce_sum(const float *a, float *out, std::size_t n);
+// Backward matmul kernels expect dimensions in (m, n, k) order
 void metal_matmul_backward_a(const float *g, const float *b, float *ga,
                              std::size_t m, std::size_t n, std::size_t k);
 void metal_matmul_backward_b(const float *g, const float *a, float *gb,

--- a/metal-tensor/metal/runtime/MetalKernels.mm
+++ b/metal-tensor/metal/runtime/MetalKernels.mm
@@ -164,6 +164,7 @@ void metal_reduce_sum(const float *a, float *out, std::size_t n) {
   ctx.return_command_queue(queue);
 }
 
+// Parameters follow (m, n, k)
 void metal_matmul_backward_a(const float *g, const float *b, float *ga,
                              std::size_t m, std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
@@ -207,6 +208,7 @@ void metal_matmul_backward_a(const float *g, const float *b, float *ga,
   ctx.return_command_queue(queue);
 }
 
+// Parameters follow (m, n, k)
 void metal_matmul_backward_b(const float *g, const float *a, float *gb,
                              std::size_t m, std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
@@ -315,6 +317,7 @@ void metal_reduce_sum(const float *a, float *out, std::size_t n) {
   out[0] = s;
 }
 
+// Parameters follow (m, n, k)
 void metal_matmul_backward_a(const float *g, const float *b, float *ga,
                              std::size_t m, std::size_t n, std::size_t k) {
   for (std::size_t i = 0; i < m; ++i) {
@@ -327,6 +330,7 @@ void metal_matmul_backward_a(const float *g, const float *b, float *ga,
   }
 }
 
+// Parameters follow (m, n, k)
 void metal_matmul_backward_b(const float *g, const float *a, float *gb,
                              std::size_t m, std::size_t n, std::size_t k) {
   for (std::size_t i = 0; i < k; ++i) {

--- a/metal-tensor/tests/tensor_tests.cpp
+++ b/metal-tensor/tests/tensor_tests.cpp
@@ -382,52 +382,77 @@ TEST(TensorTest, AutogradMatmulMetal) {
 
 TEST(TensorTest, AutogradSumMetal) {
   std::array<std::int64_t, 8> shape{4, 1, 1, 1, 1, 1, 1, 1};
-  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
-  auto *p = static_cast<float *>(t.data_ptr());
+  Tensor tc = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *cp = static_cast<float *>(tc.data_ptr());
   for (int i = 0; i < 4; ++i)
-    p[i] = static_cast<float>(i + 1);
+    cp[i] = static_cast<float>(i + 1);
+  tc.set_requires_grad(true);
+  Tensor sc = tc.sum();
+  sc.backward();
+  Tensor g_exp = tc.grad();
+
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  std::memcpy(t.data_ptr(), tc.data_ptr(), 4 * sizeof(float));
   t.set_requires_grad(true);
   Tensor m = t.to(Device::mps);
   Tensor s = m.sum();
   s.backward();
   Tensor g = m.grad().to(Device::cpu);
   auto *gp = static_cast<float *>(g.data_ptr());
+  auto *exp_p = static_cast<float *>(g_exp.data_ptr());
   for (int i = 0; i < 4; ++i)
-    EXPECT_FLOAT_EQ(gp[i], 1.0f);
+    EXPECT_FLOAT_EQ(gp[i], exp_p[i]);
 }
 
 TEST(TensorTest, AutogradMeanMetal) {
   std::array<std::int64_t, 8> shape{4, 1, 1, 1, 1, 1, 1, 1};
-  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
-  auto *p = static_cast<float *>(t.data_ptr());
+  Tensor tc = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *cp = static_cast<float *>(tc.data_ptr());
   for (int i = 0; i < 4; ++i)
-    p[i] = static_cast<float>(i + 1);
+    cp[i] = static_cast<float>(i + 1);
+  tc.set_requires_grad(true);
+  Tensor sc = tc.mean();
+  sc.backward();
+  Tensor g_exp = tc.grad();
+
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  std::memcpy(t.data_ptr(), tc.data_ptr(), 4 * sizeof(float));
   t.set_requires_grad(true);
   Tensor m = t.to(Device::mps);
   Tensor s = m.mean();
   s.backward();
   Tensor g = m.grad().to(Device::cpu);
   auto *gp = static_cast<float *>(g.data_ptr());
+  auto *exp_p = static_cast<float *>(g_exp.data_ptr());
   for (int i = 0; i < 4; ++i)
-    EXPECT_FLOAT_EQ(gp[i], 0.25f);
+    EXPECT_FLOAT_EQ(gp[i], exp_p[i]);
 }
 
 TEST(TensorTest, AutogradViewMetal) {
   std::array<std::int64_t, 8> shape{2, 2, 1, 1, 1, 1, 1, 1};
-  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
-  auto *p = static_cast<float *>(t.data_ptr());
+  Tensor tc = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *cp = static_cast<float *>(tc.data_ptr());
   for (int i = 0; i < 4; ++i)
-    p[i] = 1.0f;
+    cp[i] = 1.0f;
+  tc.set_requires_grad(true);
+  std::array<std::int64_t, 8> newShape{4, 1, 1, 1, 1, 1, 1, 1};
+  Tensor vc = tc.view(newShape);
+  Tensor sc = vc.sum();
+  sc.backward();
+  Tensor g_exp = tc.grad();
+
+  Tensor t = Tensor::empty(shape, DType::f32, Device::cpu);
+  std::memcpy(t.data_ptr(), tc.data_ptr(), 4 * sizeof(float));
   t.set_requires_grad(true);
   Tensor m = t.to(Device::mps);
-  std::array<std::int64_t, 8> newShape{4, 1, 1, 1, 1, 1, 1, 1};
   Tensor v = m.view(newShape);
   Tensor s = v.sum();
   s.backward();
   Tensor g = m.grad().to(Device::cpu);
   auto *gp = static_cast<float *>(g.data_ptr());
+  auto *exp_p = static_cast<float *>(g_exp.data_ptr());
   for (int i = 0; i < 4; ++i)
-    EXPECT_FLOAT_EQ(gp[i], 1.0f);
+    EXPECT_FLOAT_EQ(gp[i], exp_p[i]);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- compile MatmulBackward, MeanBackward, SumBackward, and ViewBackward as separate autograd sources
- copy matmul inputs to the incoming gradient's device before dispatching Metal kernels or running CPU fallback loops
- fetch scalar gradients on the CPU for sum and mean before filling results via Metal or host paths
- verify matmul, sum, mean, and view gradients on MPS against CPU references

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_OBJCXX_COMPILER=/usr/bin/clang++` (failed: Metal SDK requires macOS and Xcode command line tools)
- `cmake --build build --target test` (failed: ninja: error: loading 'build.ninja': No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689a58a3d630832eb0ca7d49a6a6424c