### PR TITLE
Add autograd for elementwise multiply and transpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - Intrusive reference counted `Storage` objects that permit zero-copy wrapping of external buffers through `Tensor::fromData`.
 - Host and device transfers mediated by `Tensor::to`, yielding zero-copy aliases when the destination `Device` matches the source.
 - Allocation profiling managed by `metal/common/Profiling.h`. When `ORCHARD_TENSOR_PROFILE` is present in the environment, allocation and release events stream to `/tmp/orchard_tensor_profile.log`, and `dump_live_tensors` reports outstanding buffers.
-- Autograd foundations supplied by the `requires_grad` flag, gradient accumulation in `Tensor::grad`, and dedicated nodes for matmul, reductions, view, and elementwise add.
+- Autograd foundations supplied by the `requires_grad` flag, gradient accumulation in `Tensor::grad`, and dedicated nodes for matmul, reductions, view, elementwise add and multiply, and transpose.
 - Initial Metal compute kernels, located under `metal-tensor/metal/kernels/`, implementing vector addition, matmul, and whole-tensor reductions with automatic fallback to CPU code when Metal execution is unavailable.
 
 ## Building
@@ -27,7 +27,7 @@
 Run cmake --build build --target test to execute the suite under `metal-tensor/tests`. The tests cover CPU and Metal paths, queue reuse, profiling hooks, and autograd gradients. Always attempt to configure and run tests before submitting a pull request. Even on systems lacking the Metal SDK, failing output is still valuable and should be reported in the pull request.
 
 ## Autograd Notes
-Tensors opt into gradient tracking through the requires_grad property. Operations such as Tensor::add, Tensor::matmul, Tensor::sum, Tensor::mean, and Tensor::view register Node instances connected by Edge relationships. Calling backward performs a reverse traversal to populate Tensor::grad on leaf tensors. Matmul, reductions, view, and elementwise add are currently implemented.
+Tensors opt into gradient tracking through the requires_grad property. Operations such as Tensor::add, Tensor::mul, Tensor::matmul, Tensor::sum, Tensor::mean, Tensor::transpose, and Tensor::view register Node instances connected by Edge relationships. Calling backward performs a reverse traversal to populate Tensor::grad on leaf tensors. Matmul, reductions, view, elementwise add and multiply, and transpose are currently implemented.
 
 ## Continuous Integration
 The macOS workflow described in .github/workflows/macos.yml installs dependencies through Homebrew, configures the project with the Ninja generator, treats warnings as errors, and executes the full test suite. Build artifacts and ccache directories are cached to accelerate subsequent runs. Any warning or failing test causes the pipeline to halt.
@@ -36,7 +36,7 @@ The macOS workflow described in .github/workflows/macos.yml installs dependencie
 Setting ORCHARD_TENSOR_PROFILE enables logging of allocation and deallocation events along with explicit dumps triggered by dump_live_tensors. Logs accumulate at /tmp/orchard_tensor_profile.log for offline inspection.
 
 ## Current Status
-- Tensor v0 handles intrusive storage, host and device transfers, and validated gradients for matmul, reductions, view, and elementwise addition.
+- Tensor v0 handles intrusive storage, host and device transfers, and validated gradients for matmul, reductions, view, elementwise addition and multiply, and transpose.
 - The PyTorch bridge under `experimental/` remains available for regression checks but is omitted from standard builds.
 - macOS continuous integration enforces warnings-as-errors and executes the test suite; Linux hosts provide diagnostic failures only.
 - Documentation covers design specifications, tensor features, and project status but evolves with each milestone.

--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -2,8 +2,10 @@ add_library(orchard_core STATIC
   metal/core/core.cpp
   metal/core/autograd/Node.cpp
   metal/core/autograd/MatmulBackward.cpp
+  metal/core/autograd/MulBackward.cpp
   metal/core/autograd/MeanBackward.cpp
   metal/core/autograd/SumBackward.cpp
+  metal/core/autograd/TransposeBackward.cpp
   metal/core/autograd/ViewBackward.cpp
   metal/core/tensor/Tensor.cpp
   metal/core/tensor/Debug.cpp

--- a/metal-tensor/README.md
+++ b/metal-tensor/README.md
@@ -6,14 +6,14 @@
 - Tensor::empty, Tensor::view, Tensor::slice, and zero-copy Tensor::fromData
 - CPU and Metal transfers via Tensor::to
 - allocation profiling and dump_live_tensors for debug tracing
-- a starter autograd engine with Tensor::requires_grad, gradient tensors, and Node and Edge graph powering backward for matmul, reductions, and view
+- a starter autograd engine with Tensor::requires_grad, gradient tensors, and Node and Edge graph powering backward for matmul, reductions, elementwise multiply, transpose, and view
 - Metal compute kernels covering vector add, matmul, and whole-tensor reductions, automatically selected when tensors live on an mps device
 
 ## Current Status
 - CPU and Metal backends allocate tensors with intrusive storage and share views without copying.
 - Host and device transfers through Tensor::to round-trip data between CPU and mps devices.
-- Tests validate contiguity, profiling logs, command-queue pooling, multi-device transfers, alignment on non-contiguous views, and gradient propagation for elementwise add, matmul, reductions, and view transforms.
-- Vector addition, matmul, and full reductions ship with Metal kernels for forward and backward paths.
+- Tests validate contiguity, profiling logs, command-queue pooling, multi-device transfers, alignment on non-contiguous views, and gradient propagation for elementwise add, multiply, matmul, reductions, transpose, and view transforms.
+- Vector add and multiply, matmul, and full reductions ship with Metal kernels for forward and backward paths, and transpose uses a Metal kernel for backward.
 
 ## Directory map
 - `metal/` holds the implementation source
@@ -30,7 +30,7 @@
 3. Linux hosts cannot compile the project but should still attempt these commands and include the failure output in pull requests.
 
 ## Testing
-Invoke the tests with cmake --build build --target test. The suite covers contiguity, CPU arithmetic, command-queue pooling, multi-device CPU↔Metal↔CPU transfers, mixed CPU→Metal→CPU→Metal sequences, multi-threaded large tensor moves, profiling log validation with matching alloc/free counts, silent behaviour when ORCHARD_TENSOR_PROFILE is unset, alignment and zero-copy checks, and autograd gradients for elementwise add.
+Invoke the tests with cmake --build build --target test. The suite covers contiguity, CPU arithmetic, command-queue pooling, multi-device CPU↔Metal↔CPU transfers, mixed CPU→Metal→CPU→Metal sequences, multi-threaded large tensor moves, profiling log validation with matching alloc/free counts, silent behaviour when ORCHARD_TENSOR_PROFILE is unset, alignment and zero-copy checks, and autograd gradients for elementwise add, multiply, and transpose.
 
 ## Milestones
 1. Autograd support for a base operator set including matmul and reductions.

--- a/metal-tensor/metal/core/autograd/MulBackward.cpp
+++ b/metal-tensor/metal/core/autograd/MulBackward.cpp
@@ -1,0 +1,32 @@
+#include "MulBackward.h"
+#include "../../runtime/MetalKernels.h"
+
+using namespace orchard::core::tensor;
+
+namespace orchard::core::autograd {
+
+MulBackward::MulBackward(const Tensor &aa, const Tensor &bb) : a(aa), b(bb) {}
+
+void MulBackward::apply(Tensor &g) {
+  Device dev = g.device();
+  Tensor ga = Tensor::empty(a.shape(), DType::f32, dev);
+  Tensor gb = Tensor::empty(b.shape(), DType::f32, dev);
+  Tensor gg = g.to(dev);
+  Tensor aa = a.to(dev);
+  Tensor bb = b.to(dev);
+  std::size_t n = a.numel();
+  runtime::metal_mul_backward_a(static_cast<const float *>(gg.data_ptr()),
+                                static_cast<const float *>(bb.data_ptr()),
+                                static_cast<float *>(ga.data_ptr()), n);
+  runtime::metal_mul_backward_b(static_cast<const float *>(gg.data_ptr()),
+                                static_cast<const float *>(aa.data_ptr()),
+                                static_cast<float *>(gb.data_ptr()), n);
+  accumulate(a, ga.to(a.device()));
+  accumulate(b, gb.to(b.device()));
+  if (a.grad_fn())
+    a.grad_fn()->apply(a.grad());
+  if (b.grad_fn())
+    b.grad_fn()->apply(b.grad());
+}
+
+} // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/MulBackward.h
+++ b/metal-tensor/metal/core/autograd/MulBackward.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../tensor/Tensor.h"
+#include "Node.h"
+
+namespace orchard::core::autograd {
+
+struct MulBackward : Node {
+  tensor::Tensor a;
+  tensor::Tensor b;
+  MulBackward(const tensor::Tensor &aa, const tensor::Tensor &bb);
+  void apply(tensor::Tensor &g) override;
+};
+
+} // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/TransposeBackward.cpp
+++ b/metal-tensor/metal/core/autograd/TransposeBackward.cpp
@@ -1,0 +1,24 @@
+#include "TransposeBackward.h"
+#include "../../runtime/MetalKernels.h"
+
+using namespace orchard::core::tensor;
+
+namespace orchard::core::autograd {
+
+TransposeBackward::TransposeBackward(const Tensor &b, int d0, int d1)
+    : base(b), dim0(d0), dim1(d1) {}
+
+void TransposeBackward::apply(Tensor &g) {
+  int m = static_cast<int>(base.shape()[dim0]);
+  int n = static_cast<int>(base.shape()[dim1]);
+  Device dev = g.device();
+  Tensor out = Tensor::empty(base.shape(), DType::f32, dev);
+  Tensor gg = g.to(dev);
+  runtime::metal_transpose_backward(static_cast<const float *>(gg.data_ptr()),
+                                    static_cast<float *>(out.data_ptr()), m, n);
+  accumulate(base, out.to(base.device()));
+  if (base.grad_fn())
+    base.grad_fn()->apply(base.grad());
+}
+
+} // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/TransposeBackward.h
+++ b/metal-tensor/metal/core/autograd/TransposeBackward.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../tensor/Tensor.h"
+#include "Node.h"
+
+namespace orchard::core::autograd {
+
+struct TransposeBackward : Node {
+  tensor::Tensor base;
+  int dim0;
+  int dim1;
+  TransposeBackward(const tensor::Tensor &b, int d0, int d1);
+  void apply(tensor::Tensor &g) override;
+};
+
+} // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/tensor/Tensor.cpp
+++ b/metal-tensor/metal/core/tensor/Tensor.cpp
@@ -3,10 +3,13 @@
 #include "../../runtime/MetalKernels.h"
 #include "../autograd/MatmulBackward.h"
 #include "../autograd/MeanBackward.h"
+#include "../autograd/MulBackward.h"
 #include "../autograd/Node.h"
 #include "../autograd/SumBackward.h"
+#include "../autograd/TransposeBackward.h"
 #include "../autograd/ViewBackward.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -214,6 +217,35 @@ Tensor Tensor::view(const std::array<std::int64_t, 8> &newShape) const {
   t.set_requires_grad(requires_grad_);
   if (requires_grad_) {
     t.set_grad_fn(std::make_shared<autograd::ViewBackward>(*this));
+  } else {
+    t.set_grad_fn(grad_fn_);
+  }
+  return t;
+}
+
+Tensor Tensor::transpose(int dim0, int dim1) const {
+  if (!impl_ || !impl_->storage)
+    return Tensor{};
+  int r = rank_of(impl_->shape);
+  if (dim0 < 0 || dim1 < 0 || dim0 >= r || dim1 >= r)
+    return Tensor{};
+  auto *impl = new TensorImpl{};
+  os_unfair_lock_lock(&this->impl_->lock);
+  this->impl_->storage->retain();
+  os_unfair_lock_unlock(&this->impl_->lock);
+  impl->storage = this->impl_->storage;
+  impl->dtype = this->impl_->dtype;
+  impl->device = this->impl_->device;
+  impl->shape = this->impl_->shape;
+  impl->strides = this->impl_->strides;
+  std::swap(impl->shape[dim0], impl->shape[dim1]);
+  std::swap(impl->strides[dim0], impl->strides[dim1]);
+  impl->offset = this->impl_->offset;
+  Tensor t(impl);
+  t.set_requires_grad(requires_grad_);
+  if (requires_grad_) {
+    t.set_grad_fn(
+        std::make_shared<autograd::TransposeBackward>(*this, dim0, dim1));
   } else {
     t.set_grad_fn(grad_fn_);
   }
@@ -428,33 +460,8 @@ Tensor Tensor::mul(const Tensor &other) const {
   }
   bool rg = requires_grad_ || other.requires_grad_;
   out.set_requires_grad(rg);
-  if (rg) {
-    struct MulNode : autograd::Node {
-      Tensor a;
-      Tensor b;
-      MulNode(const Tensor &aa, const Tensor &bb) : a(aa), b(bb) {}
-      void apply(Tensor &g) override {
-        Tensor ga = Tensor::empty(a.shape(), DType::f32, Device::cpu);
-        Tensor gb = Tensor::empty(b.shape(), DType::f32, Device::cpu);
-        auto *gp = static_cast<const float *>(g.to(Device::cpu).data_ptr());
-        auto *ap = static_cast<const float *>(a.to(Device::cpu).data_ptr());
-        auto *bp = static_cast<const float *>(b.to(Device::cpu).data_ptr());
-        auto *gap = static_cast<float *>(ga.data_ptr());
-        auto *gbp = static_cast<float *>(gb.data_ptr());
-        for (std::size_t i = 0; i < a.numel(); ++i) {
-          gap[i] = gp[i] * bp[i];
-          gbp[i] = gp[i] * ap[i];
-        }
-        accumulate(a, ga.to(a.device()));
-        accumulate(b, gb.to(b.device()));
-        if (a.grad_fn())
-          a.grad_fn()->apply(a.grad());
-        if (b.grad_fn())
-          b.grad_fn()->apply(b.grad());
-      }
-    };
-    out.set_grad_fn(std::make_shared<MulNode>(*this, other));
-  }
+  if (rg)
+    out.set_grad_fn(std::make_shared<autograd::MulBackward>(*this, other));
   return out;
 }
 

--- a/metal-tensor/metal/core/tensor/Tensor.h
+++ b/metal-tensor/metal/core/tensor/Tensor.h
@@ -31,6 +31,7 @@ public:
   fromData(void *data, const std::array<std::int64_t, 8> &shape, DType dtype,
            Device dev, std::function<void(void *)> deleter = nullptr);
   [[nodiscard]] Tensor view(const std::array<std::int64_t, 8> &newShape) const;
+  [[nodiscard]] Tensor transpose(int dim0, int dim1) const;
   [[nodiscard]] Tensor slice(int dim, int start, int end, int step = 1) const;
   [[nodiscard]] Tensor to(Device dev) const;
   [[nodiscard]] Tensor contiguous() const;

--- a/metal-tensor/metal/kernels/mul_backward.metal
+++ b/metal-tensor/metal/kernels/mul_backward.metal
@@ -1,0 +1,16 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void mul_backward_a(const device float *grad [[buffer(0)]],
+                           const device float *b [[buffer(1)]],
+                           device float *out [[buffer(2)]],
+                           uint gid [[thread_position_in_grid]]) {
+  out[gid] = grad[gid] * b[gid];
+}
+
+kernel void mul_backward_b(const device float *grad [[buffer(0)]],
+                           const device float *a [[buffer(1)]],
+                           device float *out [[buffer(2)]],
+                           uint gid [[thread_position_in_grid]]) {
+  out[gid] = grad[gid] * a[gid];
+}

--- a/metal-tensor/metal/kernels/transpose_backward.metal
+++ b/metal-tensor/metal/kernels/transpose_backward.metal
@@ -1,0 +1,14 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void transpose_backward(const device float *grad [[buffer(0)]],
+                               device float *out [[buffer(1)]],
+                               constant uint &m [[buffer(2)]],
+                               constant uint &n [[buffer(3)]],
+                               uint gid [[thread_position_in_grid]]) {
+  uint row = gid / n;
+  uint col = gid % n;
+  if (row >= m || col >= n)
+    return;
+  out[row * n + col] = grad[col * m + row];
+}

--- a/metal-tensor/metal/runtime/MetalKernels.h
+++ b/metal-tensor/metal/runtime/MetalKernels.h
@@ -8,6 +8,12 @@ void metal_mul(const float *a, const float *b, float *c, std::size_t n);
 void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
                   std::size_t n, std::size_t k);
 void metal_reduce_sum(const float *a, float *out, std::size_t n);
+void metal_mul_backward_a(const float *g, const float *b, float *ga,
+                          std::size_t n);
+void metal_mul_backward_b(const float *g, const float *a, float *gb,
+                          std::size_t n);
+void metal_transpose_backward(const float *g, float *out, std::size_t m,
+                              std::size_t n);
 // Backward matmul kernels expect dimensions in (m, n, k) order
 void metal_matmul_backward_a(const float *g, const float *b, float *ga,
                              std::size_t m, std::size_t n, std::size_t k);

--- a/metal-tensor/metal/runtime/MetalKernels.mm
+++ b/metal-tensor/metal/runtime/MetalKernels.mm
@@ -84,6 +84,80 @@ void metal_mul(const float *a, const float *b, float *c, std::size_t n) {
   ctx.return_command_queue(queue);
 }
 
+void metal_mul_backward_a(const float *g, const float *b, float *ga,
+                          std::size_t n) {
+  static id<MTLComputePipelineState> pipeline = nil;
+  MetalContext &ctx = metal_context();
+  if (!pipeline) {
+    std::ifstream ifs("metal/kernels/mul_backward.metal");
+    std::string src((std::istreambuf_iterator<char>(ifs)),
+                    std::istreambuf_iterator<char>());
+    NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
+                                               length:src.size()
+                                             encoding:NSUTF8StringEncoding];
+    NSError *err = nil;
+    id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
+                                                    options:nil
+                                                      error:&err];
+    [nsSrc release];
+    id<MTLFunction> fn = [lib newFunctionWithName:@"mul_backward_a"];
+    pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
+    [fn release];
+    [lib release];
+  }
+  id<MTLCommandQueue> queue = ctx.acquire_command_queue();
+  id<MTLCommandBuffer> cmd = [queue commandBuffer];
+  id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+  [enc setComputePipelineState:pipeline];
+  [enc setBuffer:(__bridge id<MTLBuffer>)(const void *)g offset:0 atIndex:0];
+  [enc setBuffer:(__bridge id<MTLBuffer>)(const void *)b offset:0 atIndex:1];
+  [enc setBuffer:(__bridge id<MTLBuffer>)ga offset:0 atIndex:2];
+  MTLSize grid = MTLSizeMake(n, 1, 1);
+  MTLSize thread = MTLSizeMake(1, 1, 1);
+  [enc dispatchThreads:grid threadsPerThreadgroup:thread];
+  [enc endEncoding];
+  [cmd commit];
+  [cmd waitUntilCompleted];
+  ctx.return_command_queue(queue);
+}
+
+void metal_mul_backward_b(const float *g, const float *a, float *gb,
+                          std::size_t n) {
+  static id<MTLComputePipelineState> pipeline = nil;
+  MetalContext &ctx = metal_context();
+  if (!pipeline) {
+    std::ifstream ifs("metal/kernels/mul_backward.metal");
+    std::string src((std::istreambuf_iterator<char>(ifs)),
+                    std::istreambuf_iterator<char>());
+    NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
+                                               length:src.size()
+                                             encoding:NSUTF8StringEncoding];
+    NSError *err = nil;
+    id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
+                                                    options:nil
+                                                      error:&err];
+    [nsSrc release];
+    id<MTLFunction> fn = [lib newFunctionWithName:@"mul_backward_b"];
+    pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
+    [fn release];
+    [lib release];
+  }
+  id<MTLCommandQueue> queue = ctx.acquire_command_queue();
+  id<MTLCommandBuffer> cmd = [queue commandBuffer];
+  id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+  [enc setComputePipelineState:pipeline];
+  [enc setBuffer:(__bridge id<MTLBuffer>)(const void *)g offset:0 atIndex:0];
+  [enc setBuffer:(__bridge id<MTLBuffer>)(const void *)a offset:0 atIndex:1];
+  [enc setBuffer:(__bridge id<MTLBuffer>)gb offset:0 atIndex:2];
+  MTLSize grid = MTLSizeMake(n, 1, 1);
+  MTLSize thread = MTLSizeMake(1, 1, 1);
+  [enc dispatchThreads:grid threadsPerThreadgroup:thread];
+  [enc endEncoding];
+  [cmd commit];
+  [cmd waitUntilCompleted];
+  ctx.return_command_queue(queue);
+}
+
 void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
                   std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
@@ -252,6 +326,46 @@ void metal_matmul_backward_b(const float *g, const float *a, float *gb,
   ctx.return_command_queue(queue);
 }
 
+void metal_transpose_backward(const float *g, float *out, std::size_t m,
+                              std::size_t n) {
+  static id<MTLComputePipelineState> pipeline = nil;
+  MetalContext &ctx = metal_context();
+  if (!pipeline) {
+    std::ifstream ifs("metal/kernels/transpose_backward.metal");
+    std::string src((std::istreambuf_iterator<char>(ifs)),
+                    std::istreambuf_iterator<char>());
+    NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
+                                               length:src.size()
+                                             encoding:NSUTF8StringEncoding];
+    NSError *err = nil;
+    id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
+                                                    options:nil
+                                                      error:&err];
+    [nsSrc release];
+    id<MTLFunction> fn = [lib newFunctionWithName:@"transpose_backward"];
+    pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
+    [fn release];
+    [lib release];
+  }
+  id<MTLCommandQueue> queue = ctx.acquire_command_queue();
+  id<MTLCommandBuffer> cmd = [queue commandBuffer];
+  id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+  [enc setComputePipelineState:pipeline];
+  [enc setBuffer:(__bridge id<MTLBuffer>)(const void *)g offset:0 atIndex:0];
+  [enc setBuffer:(__bridge id<MTLBuffer>)out offset:0 atIndex:1];
+  uint32_t mm = static_cast<uint32_t>(m);
+  uint32_t nn = static_cast<uint32_t>(n);
+  [enc setBytes:&mm length:sizeof(uint32_t) atIndex:2];
+  [enc setBytes:&nn length:sizeof(uint32_t) atIndex:3];
+  MTLSize grid = MTLSizeMake(m * n, 1, 1);
+  MTLSize thread = MTLSizeMake(1, 1, 1);
+  [enc dispatchThreads:grid threadsPerThreadgroup:thread];
+  [enc endEncoding];
+  [cmd commit];
+  [cmd waitUntilCompleted];
+  ctx.return_command_queue(queue);
+}
+
 void metal_fill(float *out, float value, std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
@@ -298,6 +412,18 @@ void metal_mul(const float *a, const float *b, float *c, std::size_t n) {
     c[i] = a[i] * b[i];
 }
 
+void metal_mul_backward_a(const float *g, const float *b, float *ga,
+                          std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    ga[i] = g[i] * b[i];
+}
+
+void metal_mul_backward_b(const float *g, const float *a, float *gb,
+                          std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    gb[i] = g[i] * a[i];
+}
+
 void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
                   std::size_t n, std::size_t k) {
   for (std::size_t i = 0; i < m; ++i) {
@@ -339,6 +465,15 @@ void metal_matmul_backward_b(const float *g, const float *a, float *gb,
       for (std::size_t p = 0; p < m; ++p)
         s += a[p * k + i] * g[p * n + j];
       gb[i * n + j] = s;
+    }
+  }
+}
+
+void metal_transpose_backward(const float *g, float *out, std::size_t m,
+                              std::size_t n) {
+  for (std::size_t i = 0; i < m; ++i) {
+    for (std::size_t j = 0; j < n; ++j) {
+      out[i * n + j] = g[j * m + i];
     }
   }
 }

--- a/metal-tensor/tests/tensor_tests.cpp
+++ b/metal-tensor/tests/tensor_tests.cpp
@@ -150,6 +150,30 @@ TEST(TensorAutogradTest, MulBackward) {
   }
 }
 
+TEST(TensorAutogradTest, TransposeBackward) {
+  std::array<std::int64_t, 8> aShape{2, 3, 1, 1, 1, 1, 1, 1};
+  std::array<std::int64_t, 8> cShape{3, 2, 1, 1, 1, 1, 1, 1};
+  Tensor a = Tensor::empty(aShape, DType::f32, Device::cpu);
+  Tensor c = Tensor::empty(cShape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(a.data_ptr());
+  auto *cp = static_cast<float *>(c.data_ptr());
+  for (int i = 0; i < 6; ++i) {
+    ap[i] = static_cast<float>(i + 1);
+    cp[i] = static_cast<float>(i + 1);
+  }
+  a.set_requires_grad(true);
+  Tensor t = a.transpose(0, 1);
+  Tensor prod = t.mul(c);
+  Tensor s = prod.sum();
+  s.backward();
+  auto *ag = static_cast<float *>(a.grad().data_ptr());
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_FLOAT_EQ(ag[i * 3 + j], cp[j * 2 + i]);
+    }
+  }
+}
+
 TEST(TensorAutogradTest, MatmulBackward) {
   std::array<std::int64_t, 8> aShape{2, 3, 1, 1, 1, 1, 1, 1};
   std::array<std::int64_t, 8> bShape{3, 2, 1, 1, 1, 1, 1, 1};
@@ -300,6 +324,21 @@ TEST(TensorTest, MatmulMetalMatchesCpu) {
     EXPECT_FLOAT_EQ(cp[i], mp[i]);
 }
 
+TEST(TensorTest, TransposeMetalMatchesCpu) {
+  std::array<std::int64_t, 8> aShape{2, 3, 1, 1, 1, 1, 1, 1};
+  Tensor a = Tensor::empty(aShape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(a.data_ptr());
+  for (int i = 0; i < 6; ++i)
+    ap[i] = static_cast<float>(i + 1);
+  Tensor cpu = a.transpose(0, 1).contiguous();
+  Tensor ma = a.to(Device::mps);
+  Tensor mc = ma.transpose(0, 1).contiguous().to(Device::cpu);
+  auto *cp = static_cast<float *>(cpu.data_ptr());
+  auto *mp = static_cast<float *>(mc.data_ptr());
+  for (int i = 0; i < 6; ++i)
+    EXPECT_FLOAT_EQ(cp[i], mp[i]);
+}
+
 TEST(TensorTest, SumMetalMatchesCpu) {
   std::array<std::int64_t, 8> shape{4, 1, 1, 1, 1, 1, 1, 1};
   Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
@@ -338,6 +377,45 @@ TEST(TensorTest, AutogradAddMetal) {
     EXPECT_FLOAT_EQ(agp[i], 1.0f);
     EXPECT_FLOAT_EQ(bgp[i], 1.0f);
   }
+}
+
+TEST(TensorTest, AutogradMulMetal) {
+  std::array<std::int64_t, 8> shape{3, 1, 1, 1, 1, 1, 1, 1};
+  Tensor ac = Tensor::empty(shape, DType::f32, Device::cpu);
+  Tensor bc = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(ac.data_ptr());
+  auto *bp = static_cast<float *>(bc.data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    ap[i] = static_cast<float>(i + 1);
+    bp[i] = static_cast<float>(i + 2);
+  }
+  ac.set_requires_grad(true);
+  bc.set_requires_grad(true);
+  Tensor cc = ac.mul(bc);
+  cc.backward();
+  Tensor ag_exp = ac.grad();
+  Tensor bg_exp = bc.grad();
+
+  Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
+  Tensor b = Tensor::empty(shape, DType::f32, Device::cpu);
+  std::memcpy(a.data_ptr(), ac.data_ptr(), 3 * sizeof(float));
+  std::memcpy(b.data_ptr(), bc.data_ptr(), 3 * sizeof(float));
+  a.set_requires_grad(true);
+  b.set_requires_grad(true);
+  Tensor ma = a.to(Device::mps);
+  Tensor mb = b.to(Device::mps);
+  Tensor c = ma.mul(mb);
+  c.backward();
+  Tensor ag = ma.grad().to(Device::cpu);
+  Tensor bg = mb.grad().to(Device::cpu);
+  auto *agp = static_cast<float *>(ag.data_ptr());
+  auto *bgp = static_cast<float *>(bg.data_ptr());
+  auto *ag_exp_p = static_cast<float *>(ag_exp.data_ptr());
+  auto *bg_exp_p = static_cast<float *>(bg_exp.data_ptr());
+  for (int i = 0; i < 3; ++i)
+    EXPECT_FLOAT_EQ(agp[i], ag_exp_p[i]);
+  for (int i = 0; i < 3; ++i)
+    EXPECT_FLOAT_EQ(bgp[i], bg_exp_p[i]);
 }
 
 TEST(TensorTest, AutogradMatmulMetal) {
@@ -453,6 +531,42 @@ TEST(TensorTest, AutogradViewMetal) {
   auto *exp_p = static_cast<float *>(g_exp.data_ptr());
   for (int i = 0; i < 4; ++i)
     EXPECT_FLOAT_EQ(gp[i], exp_p[i]);
+}
+
+TEST(TensorTest, AutogradTransposeMetal) {
+  std::array<std::int64_t, 8> aShape{2, 3, 1, 1, 1, 1, 1, 1};
+  std::array<std::int64_t, 8> cShape{3, 2, 1, 1, 1, 1, 1, 1};
+  Tensor ac = Tensor::empty(aShape, DType::f32, Device::cpu);
+  Tensor cc = Tensor::empty(cShape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(ac.data_ptr());
+  auto *cp = static_cast<float *>(cc.data_ptr());
+  for (int i = 0; i < 6; ++i) {
+    ap[i] = static_cast<float>(i + 1);
+    cp[i] = static_cast<float>(i + 1);
+  }
+  ac.set_requires_grad(true);
+  Tensor tc = ac.transpose(0, 1);
+  Tensor pc = tc.mul(cc);
+  Tensor sc = pc.sum();
+  sc.backward();
+  Tensor ag_exp = ac.grad();
+
+  Tensor a = Tensor::empty(aShape, DType::f32, Device::cpu);
+  Tensor c = Tensor::empty(cShape, DType::f32, Device::cpu);
+  std::memcpy(a.data_ptr(), ac.data_ptr(), 6 * sizeof(float));
+  std::memcpy(c.data_ptr(), cc.data_ptr(), 6 * sizeof(float));
+  a.set_requires_grad(true);
+  Tensor ma = a.to(Device::mps);
+  Tensor mc = c.to(Device::mps);
+  Tensor t = ma.transpose(0, 1);
+  Tensor p = t.mul(mc);
+  Tensor s = p.sum();
+  s.backward();
+  Tensor ag = ma.grad().to(Device::cpu);
+  auto *agp = static_cast<float *>(ag.data_ptr());
+  auto *ag_exp_p = static_cast<float *>(ag_exp.data_ptr());
+  for (int i = 0; i < 6; ++i)
+    EXPECT_FLOAT_EQ(agp[i], ag_exp_p[i]);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- add MulBackward and TransposeBackward nodes and wire Tensor::transpose into autograd
- implement Metal and CPU kernels for multiply and transpose backward paths
- expand tests to check multiply and transpose gradients on CPU and MPS, and document new operator coverage

## Testing
- `cmake -S . -B build -G Ninja` *(fails: cannot execute `cc1objplus`)*
- `cmake --build build --target test` *(fails: `build.ninja` missing)*


------
https://chatgpt.com/codex/tasks/task_e_689a811e9f68832ea1cbbc8e85decda5