### PR TITLE
Stabilize tensor tests on non-Apple platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ The directory layout is intentionally shallow to make navigation unambiguous:
 ## Current Status
 - Tensor v0 now layers elementwise division, constant filling, and explicit detachment on top of intrusive storage and host and device transfer paths.
 - Division backward dispatches by device, allowing CPU-only builds without Metal.
+- The Metal allocator falls back to host memory on non-Apple platforms while
+  still emitting profiling events for allocations and frees.
+- Autograd nodes retain input tensors to avoid recursive gradient application;
+  regression tests cover chained in-place scalar divisions and CPU add and mul
+  backward paths.
+- Vector and matrix broadcast tests now align shapes, resolving a prior crash.
 - Detached views share storage; `Tensor::is_alias_of` verifies aliasing and tests mutate through detached tensors and clone-before-detach paths.
 - A dedicated Metal kernel drives `Tensor::mean`, removing the final CPU post-processing step and aligning performance across devices.
 - Benchmarks cover add, mul, matmul, reduce_sum, mean, and transpose and log results beneath commit-specific directories for reproducible performance tracking.
@@ -71,6 +77,12 @@ The directory layout is intentionally shallow to make navigation unambiguous:
 - Continuous integration now covers `macos-13` (M1) and `macos-14` (M2) with Xcode 15.3 pinned and Homebrew updates disabled. A Linux job installs a clang-based Objective-C++ toolchain and is allowed to fail for diagnostics.
 - Documentation outlines tensor internals, profiling hooks, and contributor expectations yet remains a living reference.
 - GoogleTest ships as a minimal vendored copy under `third_party/googletest` so tests compile without network access; obtain upstream tests and samples from the official repository when needed.
+- The suite currently reports failures for `TensorTest.DivSafeMasksZero`,
+  `TensorTest.SumMeanAxisCpuMetal`, `TensorTest.ProfilingLogCreation`,
+  `TensorTest.ProfilingLogEntries`,
+  `TensorAutogradTest.DivScalarInplaceChainBackward`,
+  `TensorAutogradTest.TransposeBackward`, and
+  `ProfilingStressTest.AllocationAndQueuePooling`.
 
 ## Milestones
 1. Phase out the PyTorch bridge once Tensor v0 covers FlashAttention and essential autograd features.
@@ -84,3 +96,4 @@ The directory layout is intentionally shallow to make navigation unambiguous:
 3. Replace remaining CPU fallbacks with tuned Metal kernels and delete redundant host code.
 4. Grow the test matrix to cover multi-device transfers, profiling scenarios, and stress conditions.
 5. Stand up a benchmarking harness that records hardware, runtime flags, and kernel timing for every commit while archiving JSON outputs per commit.
+6. Resolve the failing tests cited above and expand coverage for CPU-only execution paths.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 - Intrusive reference counted `Storage` objects that permit zero-copy wrapping of external buffers through `Tensor::fromData`.
 - Host and device transfers mediated by `Tensor::to`, yielding zero-copy aliases when the destination `Device` matches the source.
 - Allocation profiling managed by `metal/common/Profiling.h`. When `ORCHARD_TENSOR_PROFILE` is present in the environment, allocation and release events stream to `/tmp/orchard_tensor_profile.log`, and `dump_live_tensors` reports outstanding buffers.
+- The Metal allocator falls back to host memory on non-Apple platforms while preserving allocation and free profiling logs.
 - Autograd foundations supplied by the `requires_grad` flag, gradient accumulation in `Tensor::grad`, and dedicated nodes for matmul, reductions, view, elementwise add and multiply, transpose, and division. `Tensor::detach` returns a view that shares storage but halts gradient propagation.
+- Autograd nodes retain input tensors to avoid recursive gradient application; regression tests validate chained in-place scalar divisions and CPU add and mul backward paths.
 - Initial Metal compute kernels, located under `metal-tensor/metal/kernels/`, implementing vector addition, matmul, whole-tensor reductions, and a dedicated mean kernel; each operation automatically falls back to CPU code when Metal execution is unavailable.
 - Constant filling through `Tensor::fill` sets every element to a value on both CPU and Metal devices.
 - `Tensor::div` checks denominators for zero and can mask them when a safe flag
@@ -29,6 +31,7 @@
 
 ## Testing
 Run `cmake --build build --target test` to execute the suite under `metal-tensor/tests`. The tests cover CPU and Metal paths, queue reuse, profiling hooks, and autograd gradients. Always attempt to configure and run tests before submitting a pull request. Even on systems lacking the Metal SDK, failing output is still valuable and should be reported in the pull request.
+Current failures on non-Apple hosts include `TensorTest.DivSafeMasksZero`, `TensorTest.SumMeanAxisCpuMetal`, `TensorTest.ProfilingLogCreation`, `TensorTest.ProfilingLogEntries`, `TensorAutogradTest.DivScalarInplaceChainBackward`, `TensorAutogradTest.TransposeBackward`, and `ProfilingStressTest.AllocationAndQueuePooling`.
 
 ## Benchmarking
 Invoke `python benchmarks/run.py -o /tmp/bench` after building to capture kernel timings, hardware details, and runtime flags. Results are written to `/tmp/bench/<commit>/benchmarks.json` where `<commit>` is the short Git hash. The harness exercises addition, multiplication, matmul, reduce_sum, mean, and transpose and enables reproducible comparisons across commits.
@@ -44,6 +47,7 @@ Setting ORCHARD_TENSOR_PROFILE enables logging of allocation and deallocation ev
 
 ## Current Status
 - Tensor v0 handles intrusive storage, host and device transfers, elementwise division, constant filling, explicit detachment, and validated gradients for matmul, reductions, view, elementwise addition and multiply, division, and transpose.
+- The Metal allocator falls back to host memory on non-Apple platforms and broadcast tests align shapes to avoid prior crashes; the failing cases listed in the Testing section remain open.
 - The PyTorch bridge under `experimental/` remains available for regression checks but is omitted from standard builds.
 - macOS continuous integration enforces warnings-as-errors and executes the test suite; Linux hosts provide diagnostic failures only.
 - Fused FlashAttention backward kernels with dropout are present under `experimental/` and enable end-to-end gradient checks for keys and values.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The `docs` directory collects narrative material that spans the entire project. 
 
 ## Current Status
 - `project_status.md` and `tensor.md` are current as of August 2025 and chart both the experimental bridge and the Metal-native tensor implementation.
-- Recent updates describe elementwise division, constant tensor filling, explicit detachment, the Metal mean kernel, and the CPU-only fallback documented in the Toolchain section where Metal discovery is gated on `CMAKE_SYSTEM_NAME` and a stub `Metal::Metal` target unblocks non-Apple hosts.
+- Recent updates describe elementwise division, constant tensor filling, explicit detachment, the Metal mean kernel, and the CPU-only fallback documented in the Toolchain section where Metal discovery is gated on `CMAKE_SYSTEM_NAME` and a stub `Metal::Metal` target unblocks non-Apple hosts. The Metal allocator now falls back to host memory when Metal APIs are unavailable while still logging profiling events. Autograd nodes retain inputs to block recursive gradients with regression tests for chained in-place scalar divisions and CPU add and mul backward paths, and broadcast tests align shapes to avoid crashes. The current test run reports failures for `TensorTest.DivSafeMasksZero`, `TensorTest.SumMeanAxisCpuMetal`, `TensorTest.ProfilingLogCreation`, `TensorTest.ProfilingLogEntries`, `TensorAutogradTest.DivScalarInplaceChainBackward`, `TensorAutogradTest.TransposeBackward`, and `ProfilingStressTest.AllocationAndQueuePooling`.
 - Design specifications under `metal-tensor/docs/` provide deeper notes on kernels, runtime contexts, and autograd scaffolding.
 - Documentation is actively maintained yet lacks full API references and architecture diagrams.
 

--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -18,7 +18,11 @@ This document captures the current state of the Orchard effort and the path forw
     - helper Tensor::is_alias_of with tests mutating detached views and clone-before-detach paths to verify storage aliasing
     - seeded autograd and validated gradients for elementwise add, divide, matmul, mean, reductions, and view transforms across CPU and Metal
     - division gradients dispatch by device allowing CPU-only builds without Metal
-- macOS continuous integration caches builds, treats warnings as errors, and runs the test suite on every pull request.
+    - the Metal allocator falls back to CPU memory on non-Apple hosts while still logging profiling events
+    - autograd nodes retain inputs to avoid recursive gradient application with tests covering chained in-place scalar divisions and CPU add and mul backward paths
+    - vector and matrix broadcast tests now align shapes to prevent prior crashes
+    - the test suite currently reports failures for `TensorTest.DivSafeMasksZero`, `TensorTest.SumMeanAxisCpuMetal`, `TensorTest.ProfilingLogCreation`, `TensorTest.ProfilingLogEntries`, `TensorAutogradTest.DivScalarInplaceChainBackward`, `TensorAutogradTest.TransposeBackward`, and `ProfilingStressTest.AllocationAndQueuePooling`
+  - macOS continuous integration caches builds, treats warnings as errors, and runs the test suite on every pull request.
 - Implementation requires macOS with Xcode 15+ and the Metal 4 SDK. The project does not build in this Linux environment, but agents must still attempt configuration and report failures.
 - A minimal copy of GoogleTest resides under `third_party/googletest` so tests compile without downloads; upstream tests and samples were dropped to reduce repository size.
 
@@ -28,7 +32,8 @@ This document captures the current state of the Orchard effort and the path forw
 3. Replace remaining CPU fallbacks with optimised Metal kernels.
 4. Fix CMake configuration on non-Apple platforms so CPU-only builds and tests succeed without Objective-C++.
 5. Keep macOS CI green and broaden the matrix as needed.
-6. Benchmark FlashAttention and core tensor ops and publish performance data.
+6. Resolve outstanding test failures for safe division masks, sum and mean parity on CPU and Metal, profiling log creation and entries, in-place scalar division backward, transpose backward, and allocation and queue pooling stress cases.
+7. Benchmark FlashAttention and core tensor ops and publish performance data.
 
 ## Milestones
 1. FlashAttention backward kernels with dropout support unlocking end-to-end training benchmarks.

--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -19,8 +19,9 @@ target_link_libraries(orchard_core PUBLIC uuid)
 
 add_library(orchard_metal STATIC)
 
-# Restrict Objective-C++ runtime to Apple hosts. CpuKernels.cpp mirrors the
-# Metal entry points for CPU-only builds so no .mm files are compiled.
+# Restrict Objective-C++ runtime to Apple hosts. runtime_cpu.cpp and
+# CpuKernels.cpp mirror the Metal entry points for CPU-only builds so no .mm
+# files are compiled.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_sources(orchard_metal PRIVATE
     metal/runtime/runtime.mm

--- a/metal-tensor/README.md
+++ b/metal-tensor/README.md
@@ -14,6 +14,10 @@
 - CPU and Metal backends allocate tensors with intrusive storage and share views without copying.
 - Host and device transfers through Tensor::to round-trip data between CPU and mps devices.
 - Tests validate contiguity, profiling logs, command-queue pooling, multi-device transfers, alignment on non-contiguous views, constant filling, detachment semantics, and gradient propagation for elementwise add, multiply, divide, matmul, mean, reductions, transpose, and view transforms.
+- The Metal allocator falls back to host memory when Metal APIs are unavailable while still logging profiling events.
+- Autograd nodes retain inputs to avoid recursive gradient application with regression tests for chained in-place scalar divisions and CPU add and mul backward paths.
+- Vector and matrix broadcast tests now align shapes to prevent prior crashes.
+- The test suite currently fails `TensorTest.DivSafeMasksZero`, `TensorTest.SumMeanAxisCpuMetal`, `TensorTest.ProfilingLogCreation`, `TensorTest.ProfilingLogEntries`, `TensorAutogradTest.DivScalarInplaceChainBackward`, `TensorAutogradTest.TransposeBackward`, and `ProfilingStressTest.AllocationAndQueuePooling`.
 - Vector add and multiply, division, matmul, mean, and full reductions ship with Metal kernels for forward and backward paths, and transpose uses a Metal kernel for backward.
 
 ## Directory map

--- a/metal-tensor/metal/core/autograd/AddBackward.cpp
+++ b/metal-tensor/metal/core/autograd/AddBackward.cpp
@@ -56,7 +56,9 @@ bool compute_broadcast(const std::array<std::int64_t, 8> &a_shape,
 }
 } // namespace
 
-AddBackward::AddBackward(const Tensor &aa, const Tensor &bb) : a(aa), b(bb) {}
+AddBackward::AddBackward(const Tensor &aa, const Tensor &bb)
+    : a(aa), b(bb), pa(const_cast<Tensor *>(&aa)),
+      pb(const_cast<Tensor *>(&bb)) {}
 
 void AddBackward::apply(Tensor &g) {
   Tensor gg = g.to(Device::cpu);
@@ -88,12 +90,12 @@ void AddBackward::apply(Tensor &g) {
       bo -= info.b_strides[d] * info.shape[d];
     }
   }
-  accumulate(a, ga.to(a.device()));
-  accumulate(b, gb.to(b.device()));
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
-  if (b.grad_fn())
-    b.grad_fn()->apply(b.grad());
+  accumulate(*pa, ga.to(pa->device()));
+  accumulate(*pb, gb.to(pb->device()));
+  if (pa->grad_fn() && pa->grad_fn().get() != this)
+    pa->grad_fn()->apply(pa->grad());
+  if (pb->grad_fn() && pb->grad_fn().get() != this)
+    pb->grad_fn()->apply(pb->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/AddBackward.h
+++ b/metal-tensor/metal/core/autograd/AddBackward.h
@@ -8,6 +8,8 @@ namespace orchard::core::autograd {
 struct AddBackward : Node {
   tensor::Tensor a;
   tensor::Tensor b;
+  tensor::Tensor *pa;
+  tensor::Tensor *pb;
   AddBackward(const tensor::Tensor &aa, const tensor::Tensor &bb);
   void apply(tensor::Tensor &g) override;
 };

--- a/metal-tensor/metal/core/autograd/DivBackward.cpp
+++ b/metal-tensor/metal/core/autograd/DivBackward.cpp
@@ -58,7 +58,8 @@ bool compute_broadcast(const std::array<std::int64_t, 8> &a_shape,
 } // namespace
 
 DivBackward::DivBackward(const Tensor &aa, const Tensor &bb, bool s)
-    : a(aa), b(bb), safe(s) {}
+    : a(aa), b(bb), pa(const_cast<Tensor *>(&aa)),
+      pb(const_cast<Tensor *>(&bb)), safe(s) {}
 
 void DivBackward::apply(Tensor &g) {
   if (g.device() == Device::mps) {
@@ -72,8 +73,12 @@ void DivBackward::apply(Tensor &g) {
                                   static_cast<const float *>(a.data_ptr()),
                                   static_cast<const float *>(b.data_ptr()),
                                   static_cast<float *>(gb.data_ptr()), n);
-    accumulate(a, ga);
-    accumulate(b, gb);
+    accumulate(*pa, ga);
+    accumulate(*pb, gb);
+    if (pa->grad_fn() && pa->grad_fn().get() != this)
+      pa->grad_fn()->apply(pa->grad());
+    if (pb->grad_fn() && pb->grad_fn().get() != this)
+      pb->grad_fn()->apply(pb->grad());
   } else {
     Tensor gg = g.to(Device::cpu);
     Tensor aa = a.to(Device::cpu);
@@ -109,13 +114,13 @@ void DivBackward::apply(Tensor &g) {
         bo -= info.b_strides[d] * info.shape[d];
       }
     }
-    accumulate(a, ga.to(a.device()));
-    accumulate(b, gb.to(b.device()));
+    accumulate(*pa, ga.to(pa->device()));
+    accumulate(*pb, gb.to(pb->device()));
   }
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
-  if (b.grad_fn())
-    b.grad_fn()->apply(b.grad());
+  if (pa->grad_fn() && pa->grad_fn().get() != this)
+    pa->grad_fn()->apply(pa->grad());
+  if (pb->grad_fn() && pb->grad_fn().get() != this)
+    pb->grad_fn()->apply(pb->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/DivBackward.h
+++ b/metal-tensor/metal/core/autograd/DivBackward.h
@@ -8,6 +8,8 @@ namespace orchard::core::autograd {
 struct DivBackward : Node {
   tensor::Tensor a;
   tensor::Tensor b;
+  tensor::Tensor *pa;
+  tensor::Tensor *pb;
   bool safe{false};
   DivBackward(const tensor::Tensor &aa, const tensor::Tensor &bb, bool s);
   void apply(tensor::Tensor &g) override;

--- a/metal-tensor/metal/core/autograd/DivScalarBackward.cpp
+++ b/metal-tensor/metal/core/autograd/DivScalarBackward.cpp
@@ -5,7 +5,7 @@ using namespace orchard::core::tensor;
 namespace orchard::core::autograd {
 
 DivScalarBackward::DivScalarBackward(const Tensor &aa, float s, bool sf)
-    : a(aa), scalar(s), safe(sf) {}
+    : a(aa), pa(const_cast<Tensor *>(&aa)), scalar(s), safe(sf) {}
 
 void DivScalarBackward::apply(Tensor &g) {
   Tensor gg = g.to(Device::cpu);
@@ -20,9 +20,12 @@ void DivScalarBackward::apply(Tensor &g) {
     for (std::size_t i = 0; i < n; ++i)
       gap[i] = gp[i] / scalar;
   }
-  accumulate(a, ga.to(a.device()));
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
+  Tensor ga_t = ga.to(pa->device());
+  if (a.grad_fn()) {
+    a.grad_fn()->apply(ga_t);
+  } else {
+    accumulate(*pa, ga_t);
+  }
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/DivScalarBackward.h
+++ b/metal-tensor/metal/core/autograd/DivScalarBackward.h
@@ -7,6 +7,7 @@ namespace orchard::core::autograd {
 
 struct DivScalarBackward : Node {
   tensor::Tensor a;
+  tensor::Tensor *pa;
   float scalar;
   bool safe{false};
   DivScalarBackward(const tensor::Tensor &aa, float s, bool sf);

--- a/metal-tensor/metal/core/autograd/MatmulBackward.cpp
+++ b/metal-tensor/metal/core/autograd/MatmulBackward.cpp
@@ -8,7 +8,8 @@ using namespace orchard::core::tensor;
 namespace orchard::core::autograd {
 
 MatmulBackward::MatmulBackward(const Tensor &aa, const Tensor &bb)
-    : a(aa), b(bb) {}
+    : a(aa), b(bb), pa(const_cast<Tensor *>(&aa)),
+      pb(const_cast<Tensor *>(&bb)) {}
 
 void MatmulBackward::apply(Tensor &g) {
   auto m = a.shape()[0];
@@ -51,12 +52,12 @@ void MatmulBackward::apply(Tensor &g) {
       }
     }
   }
-  accumulate(a, ga.to(a.device()));
-  accumulate(b, gb.to(b.device()));
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
-  if (b.grad_fn())
-    b.grad_fn()->apply(b.grad());
+  accumulate(*pa, ga.to(pa->device()));
+  accumulate(*pb, gb.to(pb->device()));
+  if (pa->grad_fn() && pa->grad_fn().get() != this)
+    pa->grad_fn()->apply(pa->grad());
+  if (pb->grad_fn() && pb->grad_fn().get() != this)
+    pb->grad_fn()->apply(pb->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/MatmulBackward.h
+++ b/metal-tensor/metal/core/autograd/MatmulBackward.h
@@ -8,6 +8,8 @@ namespace orchard::core::autograd {
 struct MatmulBackward : Node {
   tensor::Tensor a;
   tensor::Tensor b;
+  tensor::Tensor *pa;
+  tensor::Tensor *pb;
   MatmulBackward(const tensor::Tensor &aa, const tensor::Tensor &bb);
   void apply(tensor::Tensor &g) override;
 };

--- a/metal-tensor/metal/core/autograd/MeanBackward.cpp
+++ b/metal-tensor/metal/core/autograd/MeanBackward.cpp
@@ -7,9 +7,11 @@ using namespace orchard::core::tensor;
 
 namespace orchard::core::autograd {
 
-MeanBackward::MeanBackward(const Tensor &aa) : a(aa) {}
+MeanBackward::MeanBackward(const Tensor &aa)
+    : a(aa), pa(const_cast<Tensor *>(&aa)) {}
 MeanBackward::MeanBackward(const Tensor &aa, int d, bool k)
-    : a(aa), dim(d), keepdim(k), reduce_all(false) {}
+    : a(aa), pa(const_cast<Tensor *>(&aa)), dim(d), keepdim(k),
+      reduce_all(false) {}
 
 void MeanBackward::apply(Tensor &g) {
   if (reduce_all) {
@@ -24,7 +26,7 @@ void MeanBackward::apply(Tensor &g) {
       for (std::size_t i = 0; i < a.numel(); ++i)
         ptr[i] = v;
     }
-    accumulate(a, grad.to(a.device()));
+    accumulate(*pa, grad.to(pa->device()));
   } else {
     Tensor gv = g;
     if (!keepdim) {
@@ -41,10 +43,10 @@ void MeanBackward::apply(Tensor &g) {
     Tensor sc = Tensor::empty({1, 1, 1, 1, 1, 1, 1, 1}, DType::f32, g.device());
     *static_cast<float *>(sc.data_ptr()) = scale;
     grad = grad.mul(sc);
-    accumulate(a, grad.to(a.device()));
+    accumulate(*pa, grad.to(pa->device()));
   }
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
+  if (pa->grad_fn() && pa->grad_fn().get() != this)
+    pa->grad_fn()->apply(pa->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/MeanBackward.h
+++ b/metal-tensor/metal/core/autograd/MeanBackward.h
@@ -7,6 +7,7 @@ namespace orchard::core::autograd {
 
 struct MeanBackward : Node {
   tensor::Tensor a;
+  tensor::Tensor *pa;
   int dim{0};
   bool keepdim{false};
   bool reduce_all{true};

--- a/metal-tensor/metal/core/autograd/MulBackward.cpp
+++ b/metal-tensor/metal/core/autograd/MulBackward.cpp
@@ -56,7 +56,9 @@ bool compute_broadcast(const std::array<std::int64_t, 8> &a_shape,
 }
 } // namespace
 
-MulBackward::MulBackward(const Tensor &aa, const Tensor &bb) : a(aa), b(bb) {}
+MulBackward::MulBackward(const Tensor &aa, const Tensor &bb)
+    : a(aa), b(bb), pa(const_cast<Tensor *>(&aa)),
+      pb(const_cast<Tensor *>(&bb)) {}
 
 void MulBackward::apply(Tensor &g) {
   Tensor gg = g.to(Device::cpu);
@@ -90,12 +92,12 @@ void MulBackward::apply(Tensor &g) {
       bo -= info.b_strides[d] * info.shape[d];
     }
   }
-  accumulate(a, ga.to(a.device()));
-  accumulate(b, gb.to(b.device()));
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
-  if (b.grad_fn())
-    b.grad_fn()->apply(b.grad());
+  accumulate(*pa, ga.to(pa->device()));
+  accumulate(*pb, gb.to(pb->device()));
+  if (pa->grad_fn() && pa->grad_fn().get() != this)
+    pa->grad_fn()->apply(pa->grad());
+  if (pb->grad_fn() && pb->grad_fn().get() != this)
+    pb->grad_fn()->apply(pb->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/MulBackward.h
+++ b/metal-tensor/metal/core/autograd/MulBackward.h
@@ -8,6 +8,8 @@ namespace orchard::core::autograd {
 struct MulBackward : Node {
   tensor::Tensor a;
   tensor::Tensor b;
+  tensor::Tensor *pa;
+  tensor::Tensor *pb;
   MulBackward(const tensor::Tensor &aa, const tensor::Tensor &bb);
   void apply(tensor::Tensor &g) override;
 };

--- a/metal-tensor/metal/core/autograd/Node.cpp
+++ b/metal-tensor/metal/core/autograd/Node.cpp
@@ -18,11 +18,11 @@ void Node::accumulate(Tensor &t, const Tensor &grad) {
   if (t.grad().device() == Device::mps) {
     auto shape = t.shape();
     auto strides = t.strides();
-    orchard::runtime::metal_add(
-        static_cast<const float *>(grad.data_ptr()),
-        static_cast<const float *>(t.grad().data_ptr()),
-        static_cast<float *>(t.grad().data_ptr()), shape.data(),
-        strides.data(), strides.data(), n);
+    orchard::runtime::metal_add(static_cast<const float *>(grad.data_ptr()),
+                                static_cast<const float *>(t.grad().data_ptr()),
+                                static_cast<float *>(t.grad().data_ptr()),
+                                shape.data(), strides.data(), strides.data(),
+                                n);
   } else {
     orchard::runtime::cpu_context().add(
         static_cast<const float *>(grad.data_ptr()),
@@ -34,19 +34,24 @@ void Node::accumulate(Tensor &t, const Tensor &grad) {
 void backward(Tensor &root) {
   if (!root.requires_grad())
     return;
-  if (!root.grad().data_ptr()) {
+  Tensor g;
+  if (root.grad().data_ptr()) {
+    g = root.grad();
+  } else {
     Tensor ones = Tensor::empty(root.shape(), root.dtype(), Device::cpu);
     auto *ptr = static_cast<float *>(ones.data_ptr());
     std::size_t n = root.numel();
     for (std::size_t i = 0; i < n; ++i)
       ptr[i] = 1.0f;
     if (root.device() == Device::mps)
-      root.set_grad(ones.to(Device::mps));
+      g = ones.to(Device::mps);
     else
-      root.set_grad(ones);
+      g = ones;
   }
   if (auto fn = root.grad_fn())
-    fn->apply(root.grad());
+    fn->apply(g);
+  else
+    root.set_grad(g);
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/SumBackward.cpp
+++ b/metal-tensor/metal/core/autograd/SumBackward.cpp
@@ -7,9 +7,11 @@ using namespace orchard::core::tensor;
 
 namespace orchard::core::autograd {
 
-SumBackward::SumBackward(const Tensor &aa) : a(aa) {}
+SumBackward::SumBackward(const Tensor &aa)
+    : a(aa), pa(const_cast<Tensor *>(&aa)) {}
 SumBackward::SumBackward(const Tensor &aa, int d, bool k)
-    : a(aa), dim(d), keepdim(k), reduce_all(false) {}
+    : a(aa), pa(const_cast<Tensor *>(&aa)), dim(d), keepdim(k),
+      reduce_all(false) {}
 
 void SumBackward::apply(Tensor &g) {
   if (reduce_all) {
@@ -23,7 +25,7 @@ void SumBackward::apply(Tensor &g) {
       for (std::size_t i = 0; i < a.numel(); ++i)
         ptr[i] = v;
     }
-    accumulate(a, grad.to(a.device()));
+    accumulate(*pa, grad.to(pa->device()));
   } else {
     Tensor gv = g;
     if (!keepdim) {
@@ -36,10 +38,10 @@ void SumBackward::apply(Tensor &g) {
     Tensor base = Tensor::empty(a.shape(), DType::f32, g.device());
     base.fill(0.0f);
     Tensor grad = base.add(gv);
-    accumulate(a, grad.to(a.device()));
+    accumulate(*pa, grad.to(pa->device()));
   }
-  if (a.grad_fn())
-    a.grad_fn()->apply(a.grad());
+  if (pa->grad_fn() && pa->grad_fn().get() != this)
+    pa->grad_fn()->apply(pa->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/SumBackward.h
+++ b/metal-tensor/metal/core/autograd/SumBackward.h
@@ -7,6 +7,7 @@ namespace orchard::core::autograd {
 
 struct SumBackward : Node {
   tensor::Tensor a;
+  tensor::Tensor *pa;
   int dim{0};
   bool keepdim{false};
   bool reduce_all{true};

--- a/metal-tensor/metal/core/autograd/TransposeBackward.cpp
+++ b/metal-tensor/metal/core/autograd/TransposeBackward.cpp
@@ -6,7 +6,7 @@ using namespace orchard::core::tensor;
 namespace orchard::core::autograd {
 
 TransposeBackward::TransposeBackward(const Tensor &b, int d0, int d1)
-    : base(b), dim0(d0), dim1(d1) {}
+    : base(b), pbase(const_cast<Tensor *>(&b)), dim0(d0), dim1(d1) {}
 
 void TransposeBackward::apply(Tensor &g) {
   int m = static_cast<int>(base.shape()[dim0]);
@@ -16,9 +16,9 @@ void TransposeBackward::apply(Tensor &g) {
   Tensor gg = g.to(dev);
   runtime::metal_transpose_backward(static_cast<const float *>(gg.data_ptr()),
                                     static_cast<float *>(out.data_ptr()), m, n);
-  accumulate(base, out.to(base.device()));
-  if (base.grad_fn())
-    base.grad_fn()->apply(base.grad());
+  accumulate(*pbase, out.to(pbase->device()));
+  if (pbase->grad_fn() && pbase->grad_fn().get() != this)
+    pbase->grad_fn()->apply(pbase->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/TransposeBackward.h
+++ b/metal-tensor/metal/core/autograd/TransposeBackward.h
@@ -7,6 +7,7 @@ namespace orchard::core::autograd {
 
 struct TransposeBackward : Node {
   tensor::Tensor base;
+  tensor::Tensor *pbase;
   int dim0;
   int dim1;
   TransposeBackward(const tensor::Tensor &b, int d0, int d1);

--- a/metal-tensor/metal/core/autograd/ViewBackward.cpp
+++ b/metal-tensor/metal/core/autograd/ViewBackward.cpp
@@ -4,13 +4,14 @@ using namespace orchard::core::tensor;
 
 namespace orchard::core::autograd {
 
-ViewBackward::ViewBackward(const Tensor &b) : base(b) {}
+ViewBackward::ViewBackward(const Tensor &b)
+    : base(b), pbase(const_cast<Tensor *>(&b)) {}
 
 void ViewBackward::apply(Tensor &g) {
   Tensor reshaped = g.view(base.shape());
-  accumulate(base, reshaped);
-  if (base.grad_fn())
-    base.grad_fn()->apply(base.grad());
+  accumulate(*pbase, reshaped);
+  if (pbase->grad_fn() && pbase->grad_fn().get() != this)
+    pbase->grad_fn()->apply(pbase->grad());
 }
 
 } // namespace orchard::core::autograd

--- a/metal-tensor/metal/core/autograd/ViewBackward.h
+++ b/metal-tensor/metal/core/autograd/ViewBackward.h
@@ -7,6 +7,7 @@ namespace orchard::core::autograd {
 
 struct ViewBackward : Node {
   tensor::Tensor base;
+  tensor::Tensor *pbase;
   explicit ViewBackward(const tensor::Tensor &b);
   void apply(tensor::Tensor &g) override;
 };

--- a/metal-tensor/metal/runtime/Allocator.h
+++ b/metal-tensor/metal/runtime/Allocator.h
@@ -101,9 +101,12 @@ inline void *MetalAllocator::allocate(std::size_t bytes, const char *label) {
   orchard::tensor_profile_log(oss.str());
   return result;
 #else
-  (void)bytes;
-  (void)label;
-  return nullptr;
+  void *p = nullptr;
+  posix_memalign(&p, 64, bytes);
+  std::ostringstream oss;
+  oss << "alloc " << p << ' ' << bytes << ' ' << (label ? label : "");
+  orchard::tensor_profile_log(oss.str());
+  return p;
 #endif
 }
 
@@ -115,7 +118,10 @@ inline void MetalAllocator::deallocate(void *ptr) {
   orchard::tensor_profile_log(oss.str());
   buffer = nil;
 #else
-  (void)ptr;
+  std::ostringstream oss;
+  oss << "free " << ptr;
+  orchard::tensor_profile_log(oss.str());
+  free(ptr);
 #endif
 }
 

--- a/metal-tensor/metal/runtime/runtime_cpu.cpp
+++ b/metal-tensor/metal/runtime/runtime_cpu.cpp
@@ -1,3 +1,4 @@
+// CPU-only runtime implementation used when Metal APIs are unavailable.
 #include "runtime/CpuContext.h"
 #include "runtime/MetalContext.h"
 

--- a/metal-tensor/tests/tensor_tests.cpp
+++ b/metal-tensor/tests/tensor_tests.cpp
@@ -253,6 +253,50 @@ TEST(TensorAutogradTest, DivBackwardSafeCpu) {
   EXPECT_FLOAT_EQ(bg[1], 0.0f);
   EXPECT_FLOAT_EQ(bg[2], -ap[2] / (bp[2] * bp[2]));
 }
+
+TEST(TensorAutogradTest, AddBackwardCpu) {
+  std::array<std::int64_t, 8> shape{3, 1, 1, 1, 1, 1, 1, 1};
+  Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
+  Tensor b = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(a.data_ptr());
+  auto *bp = static_cast<float *>(b.data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    ap[i] = static_cast<float>(i);
+    bp[i] = static_cast<float>(i * 2);
+  }
+  a.set_requires_grad(true);
+  b.set_requires_grad(true);
+  Tensor c = a.add(b);
+  c.backward();
+  auto *ag = static_cast<float *>(a.grad().data_ptr());
+  auto *bg = static_cast<float *>(b.grad().data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(ag[i], 1.0f);
+    EXPECT_FLOAT_EQ(bg[i], 1.0f);
+  }
+}
+
+TEST(TensorAutogradTest, MulBackwardCpu) {
+  std::array<std::int64_t, 8> shape{3, 1, 1, 1, 1, 1, 1, 1};
+  Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
+  Tensor b = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(a.data_ptr());
+  auto *bp = static_cast<float *>(b.data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    ap[i] = static_cast<float>(i + 1);
+    bp[i] = static_cast<float>(i + 2);
+  }
+  a.set_requires_grad(true);
+  b.set_requires_grad(true);
+  Tensor c = a.mul(b);
+  c.backward();
+  auto *ag = static_cast<float *>(a.grad().data_ptr());
+  auto *bg = static_cast<float *>(b.grad().data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(ag[i], bp[i]);
+    EXPECT_FLOAT_EQ(bg[i], ap[i]);
+  }
+}
 #endif
 
 TEST(TensorAutogradTest, DivScalarBackward) {
@@ -281,6 +325,44 @@ TEST(TensorAutogradTest, DivScalarInplaceBackward) {
   auto *ag = static_cast<float *>(a.grad().data_ptr());
   for (int i = 0; i < 3; ++i)
     EXPECT_FLOAT_EQ(ag[i], 0.5f);
+}
+
+TEST(TensorAutogradTest, DivScalarInplaceChainBackward) {
+  std::array<std::int64_t, 8> shape{3, 1, 1, 1, 1, 1, 1, 1};
+  Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
+  Tensor tmp = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(a.data_ptr());
+  auto *tp = static_cast<float *>(tmp.data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    ap[i] = static_cast<float>(i + 1);
+    tp[i] = static_cast<float>(i + 1);
+  }
+  a.set_requires_grad(true);
+  tmp.set_requires_grad(true);
+  Tensor b = a.add(tmp);
+  b.div_(2.0f);
+  b.backward();
+  auto *ag = static_cast<float *>(a.grad().data_ptr());
+  auto *tg = static_cast<float *>(tmp.grad().data_ptr());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(ag[i], 1.0f);
+    EXPECT_FLOAT_EQ(tg[i], 1.0f);
+  }
+}
+
+TEST(TensorAutogradTest, DivScalarDoubleInplaceBackward) {
+  std::array<std::int64_t, 8> shape{3, 1, 1, 1, 1, 1, 1, 1};
+  Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
+  auto *ap = static_cast<float *>(a.data_ptr());
+  for (int i = 0; i < 3; ++i)
+    ap[i] = static_cast<float>(i + 4);
+  a.set_requires_grad(true);
+  a.div_(2.0f);
+  a.div_(2.0f);
+  a.backward();
+  auto *ag = static_cast<float *>(a.grad().data_ptr());
+  for (int i = 0; i < 3; ++i)
+    EXPECT_FLOAT_EQ(ag[i], 0.25f);
 }
 
 TEST(TensorAutogradTest, DetachNoGrad) {
@@ -1131,7 +1213,7 @@ TEST(TensorBroadcastTest, ScalarTensor) {
 }
 
 TEST(TensorBroadcastTest, VectorMatrix) {
-  std::array<std::int64_t, 8> vShape{4, 1, 1, 1, 1, 1, 1, 1};
+  std::array<std::int64_t, 8> vShape{1, 4, 1, 1, 1, 1, 1, 1};
   std::array<std::int64_t, 8> mShape{3, 4, 1, 1, 1, 1, 1, 1};
   Tensor v = Tensor::empty(vShape, DType::f32, Device::cpu);
   Tensor m = Tensor::empty(mShape, DType::f32, Device::cpu);


### PR DESCRIPTION
## Summary
- add CPU fallback allocation to Metal allocator when Metal APIs are unavailable
- propagate gradients to original tensors and guard against recursive autograd application
- fix vector-matrix broadcast test shape to avoid crash
- add CPU-only add and mul backward tests to cover fallback path beyond division
- clarify runtime_cpu.cpp naming for non-Apple builds
- add in-place autograd regression tests for chained and repeated scalar divisions
- initialize backward gradients without pre-filling the root tensor and forward in-place division gradients to prior nodes to avoid segfaults
- document allocator fallback and outstanding test failures across AGENTS and README files

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target test` *(fails: metal_tensor_tests)*


------
https://chatgpt.com/codex/tasks/task_e_689c2a83e498832ea69a2ef035a19332