### PR TITLE
add check target to run tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The directory layout is intentionally shallow to make navigation unambiguous:
 3. Build the default target. Darwin emits `liborchard_core.a` and `liborchard_metal.a`; other platforms produce only `liborchard_core.a` as a CPU fallback.
 
 ## Test Protocol
-1. With a configured build tree, run the `test` target. Tests live under `metal-tensor/tests/` and exercise CPU/Metal paths.
+1. With a configured build tree, run the `check` target. Tests live under `metal-tensor/tests/` and exercise CPU/Metal paths.
 2. Run configure + tests before every PR and capture failure logs in the PR description when toolchains are missing.
 3. When `FETCHCONTENT_FULLY_DISCONNECTED=ON` is set during configuration the `metal_tensor_tests` target links against the trimmed `third_party/googletest` tree or a system installation so the suite executes without network access.
 4. Tests that flip `ORCHARD_TENSOR_PROFILE` must call `tensor_profile_reset` after changing the environment and purge `/tmp/orchard_tensor_profile.log` with `tensor_profile_clear_log` to keep logs isolated.
@@ -52,7 +52,7 @@ The directory layout is intentionally shallow to make navigation unambiguous:
 - Always run configure + tests locally before PRs.
 - Use `rg` for repository searches and avoid `ls -R` or `grep -R` to keep scans efficient.
 - Commit messages use the imperative mood and include a short summary line only.
-- Capture the output of `cmake -S . -B build -G Ninja` and `cmake --build build --target test` and report failures in the pull request.
+- Capture the output of `cmake -S . -B build -G Ninja` and `cmake --build build --target check` and report failures in the pull request.
 - Reference touched files by path and line number in pull request descriptions.
 - Work exclusively on the default branch and refrain from creating new branches within this repository.
 - Keep the CI matrix green. macOS runners for `macos-13` and `macos-14` must pass; the Linux diagnostic job may fail but its logs require review before merging.
@@ -60,7 +60,7 @@ The directory layout is intentionally shallow to make navigation unambiguous:
 
 ## Workflow Checklist
 1. Run `cmake -S . -B build -G Ninja` from the repository root.
-2. Invoke `cmake --build build --target test` and note any errors.
+2. Invoke `cmake --build build --target check` and note any errors.
 3. Stage changes with `git add` and create a single commit per task.
 4. Formulate a pull request summarizing the intent, the files modified, and the test outcomes.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ add_compile_options(-std=gnu++20 -Wall -Wextra -pedantic)
 
 add_subdirectory(metal-tensor)
 add_subdirectory(benchmarks)
+if(BUILD_TESTING AND TARGET metal_tensor_tests)
+  add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS metal_tensor_tests
+  )
+endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND ORCHARD_BUILD_EXPERIMENTAL)
   add_subdirectory(experimental/orchard_ops)
 endif()

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 4. Non-Apple hosts follow the same steps. Metal discovery is skipped by the `CMAKE_SYSTEM_NAME` check, Objective-C++ sources are excluded, `runtime_cpu.cpp` drives the runtime, and only `liborchard_core.a` is produced while profiling events remain logged. Capture any diagnostics and see docs/tensor.md#toolchain for details.
 
 ## Testing
-Run `cmake --build build --target test` to execute the suite under `metal-tensor/tests`. The tests cover CPU and Metal paths, queue reuse, profiling hooks with matching alloc/free counts, and autograd gradients. CPU-only builds exercise transpose, matmul, mean, and sum backward paths to validate gradients without Metal. Always attempt to configure and run tests before submitting a pull request. Even on systems lacking the Metal SDK, failing output is still valuable and should be reported in the pull request.
+Run `cmake --build build --target check` to execute the suite under `metal-tensor/tests`. The tests cover CPU and Metal paths, queue reuse, profiling hooks with matching alloc/free counts, and autograd gradients. CPU-only builds exercise transpose, matmul, mean, and sum backward paths to validate gradients without Metal. Always attempt to configure and run tests before submitting a pull request. Even on systems lacking the Metal SDK, failing output is still valuable and should be reported in the pull request.
 
 ## Benchmarking
 Invoke `python benchmarks/run.py -o /tmp/bench` after building to capture kernel timings, hardware details, runtime flags, and whether Metal or CPU kernels executed. When `ORCHARD_TENSOR_PROFILE` is set the harness embeds allocator profiling lines from `/tmp/orchard_tensor_profile.log`, and setting `ORCHARD_FORCE_CPU=1` forces CPU-only runs. Results are written to `/tmp/bench/<commit>/benchmarks.json` where `<commit>` is the short Git hash. The harness exercises addition, multiplication, matmul, reduce_sum, mean, and transpose and enables reproducible comparisons across commits.
@@ -73,7 +73,7 @@ Setting ORCHARD_TENSOR_PROFILE enables logging of allocation and deallocation ev
 ## Contributor Protocol
 - Read `AGENTS.md` in this directory before touching any file; it is the definitive governance document.
 - Configure the project with `cmake -S . -B build -G Ninja` from the repository root and capture all configure output.
-- Run `cmake --build build --target test` and include any failure logs in pull requests, even on systems lacking the Metal toolchain.
+- Run `cmake --build build --target check` and include any failure logs in pull requests, even on systems lacking the Metal toolchain.
 - When toggling `ORCHARD_TENSOR_PROFILE` in tests, invoke `tensor_profile_reset` after changing the environment and delete stale `/tmp/orchard_tensor_profile.log` with `tensor_profile_clear_log`.
 - Search the tree with `rg` instead of recursive `ls` or `grep` commands.
 - Format C++20 and Objective-C++ sources using `clang-format`.

--- a/metal-tensor/tests/CMakeLists.txt
+++ b/metal-tensor/tests/CMakeLists.txt
@@ -21,8 +21,3 @@ target_link_libraries(metal_tensor_tests PRIVATE ${GTEST_LIB} orchard_core orcha
 target_compile_features(metal_tensor_tests PRIVATE cxx_std_20)
 
 add_test(NAME metal_tensor_tests COMMAND metal_tensor_tests)
-
-# Ensure the default test target builds the unit test binary when available.
-if(TARGET test)
-  add_dependencies(test metal_tensor_tests)
-endif()


### PR DESCRIPTION
## Summary
- add custom `check` target that builds and runs unit tests
- document `check` target in testing instructions
- drop redundant dependency lines in tensor test build script

## Testing
- `cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_689f2a509de0832e80ea05cce09457c0