### PR TITLE
Document check target for tests

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,7 +18,7 @@ Each JSON file includes a top-level dictionary keyed by operation name. Entries 
 
 ## Contributor Protocol
 - Consult `../AGENTS.md` for the authoritative repository policy.
-- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root before pushing changes; include any diagnostic output in pull requests.
+- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root before pushing changes; include any diagnostic output in pull requests.
 - When configuring offline, supply `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` so the test suite links against the trimmed `third_party/googletest` tree or a system installation without attempting a download.
 - Search the repository with `rg` rather than `ls -R` or `grep -R`.
 - Do not commit generated JSON outputs or any file exceeding five megabytes.

--- a/bootstrap_codex.sh
+++ b/bootstrap_codex.sh
@@ -37,8 +37,8 @@ BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo DETACHED)"
 
 if [[ "$RUN_LOCAL_BUILD" == "1" ]]; then
   say "[local] cmake + tests"
-  cmake -S . -B build -G Ninja
-  cmake --build build --target test
+  cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+  cmake --build build --target check
 fi
 
 say "[remote] ensure ${REMOTE_MAC_SSH}:${REMOTE_MAC_PATH}"
@@ -51,8 +51,8 @@ if [[ "$REMOTE_RUN_BUILD" == "1" ]]; then
   ssh -o BatchMode=yes "$REMOTE_MAC_SSH" bash -lc "
     set -euo pipefail
     cd '${REMOTE_MAC_PATH}'
-    cmake -S . -B build -G Ninja
-    cmake --build build --target test
+    cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+    cmake --build build --target check
   "
   say "[remote] build/tests complete"
 else

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Scripts in `../benchmarks` record hardware information, runtime flags beginning 
 
 ## Contributor Protocol
 - Read `../AGENTS.md` before editing documentation; it describes required build and test steps and repository etiquette.
-- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root prior to opening a pull request; capture any failing output.
+- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root prior to opening a pull request; capture any failing output.
 - Search with `rg` instead of recursive `ls` or `grep`.
 - When profiling behaviour is exercised in tests, toggle `ORCHARD_TENSOR_PROFILE` with `tensor_profile_reset` and clear `/tmp/orchard_tensor_profile.log` via `tensor_profile_clear_log`.
 - Keep documentation free of fenced code blocks; use inline code to reference commands and identifiers.

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -34,7 +34,7 @@ These components remain only for historical comparison. They will be removed onc
 
 ## Contributor Protocol
 - Follow `../AGENTS.md` for all repository rules even when working in this experimental subtree.
-- Configure and test the project with `cmake -S . -B build -G Ninja` and `cmake --build build --target test`; include any failures in pull requests.
+- Configure and test the project with `cmake -S . -B build -G Ninja` and `cmake --build build --target check`; include any failures in pull requests.
 - Pass `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` when configuring without network access so tests link against the trimmed `third_party/googletest` tree or a system package.
 - Use `rg` for code searches; avoid recursive `ls` or `grep` commands.
 - Do not commit datasets, run outputs, or other generated files. The `data/` and `runs/` directories remain untracked to keep large artifacts out of version control.

--- a/experimental/benchmarks/README.md
+++ b/experimental/benchmarks/README.md
@@ -9,7 +9,7 @@ Update or remove these scripts once equivalent benchmarking exists for the Metal
 
 ## Contributor Protocol
 - See `../../AGENTS.md` for repository governance and mandatory build and test steps.
-- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root and attach output to pull requests.
+- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root and attach output to pull requests.
 - Supply `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` during configuration when network access is unavailable so tests link against the trimmed `third_party/googletest` tree or a system package.
 - Use `rg` instead of `ls -R` or `grep -R` when searching the repository.
 - Do not commit generated benchmark results or any large artifacts.

--- a/experimental/data/README.md
+++ b/experimental/data/README.md
@@ -11,7 +11,7 @@ Provide download scripts or links here if specific datasets become required for 
 - Consult `../../AGENTS.md` for repository rules.
 - Do not commit datasets or generated files; this directory stays untracked except for explanatory README files.
 - Document dataset origin, version, and preprocessing using inline code for commands and flags; avoid fenced code blocks.
-- Prior to submitting changes elsewhere, run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root and capture the output.
+- Prior to submitting changes elsewhere, run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root and capture the output.
 - Use `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` during configuration when offline so the test suite links against the trimmed `third_party/googletest` tree or a system installation.
 - Keep commits single-purpose with an imperative summary line and cite paths and line numbers in the pull request description.
 - Use `rg` for repository-wide searches and work only on the default branch.

--- a/experimental/orchard_ops/README.md
+++ b/experimental/orchard_ops/README.md
@@ -18,7 +18,7 @@ Current additions include a dropout-aware FlashAttention backward launcher and a
 
 ## Contributor Protocol
 - Adhere to `../../AGENTS.md` when modifying extension code or Python glue.
-- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root; record any failures in the pull request.
+- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root; record any failures in the pull request.
 - When offline, configure with `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` so tests link against the trimmed `third_party/googletest` tree or a system installation without downloading.
 - Use `rg` for symbol searches; do not rely on `ls -R` or `grep -R`.
 - Avoid committing compiled extensions, generated outputs, or files larger than five megabytes.

--- a/experimental/tests/README.md
+++ b/experimental/tests/README.md
@@ -12,7 +12,7 @@ Expand or retire these tests as the Metal-native stack reaches parity and the ex
 
 ## Contributor Protocol
 - Refer to `../../AGENTS.md` for project-wide procedures on building, testing, and committing.
-- Before modifying tests, run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root, capturing all output.
+- Before modifying tests, run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root, capturing all output.
 - Set `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` during configuration when offline so the suite links against the trimmed `third_party/googletest` tree or a system package without downloading.
 - Use `rg` for repository searches; avoid recursive directory scans with `ls -R` or `grep -R`.
 - Do not check in test artifacts or datasets; keep large files under untracked directories.

--- a/metal-tensor/README.md
+++ b/metal-tensor/README.md
@@ -40,7 +40,7 @@
 3. Non-Apple hosts follow the same steps and produce only `liborchard_core.a`; include any diagnostic output in pull requests.
 
 ## Testing
-Invoke the tests with `cmake --build build --target test`. The suite covers contiguity, CPU arithmetic, safe division masking, sum and mean parity on CPU and Metal, command-queue pooling, multi-device CPU↔Metal↔CPU transfers, mixed CPU→Metal→CPU→Metal sequences, multi-threaded large tensor moves, profiling log validation with matching alloc/free counts, silent behaviour when `ORCHARD_TENSOR_PROFILE` is unset, alignment and zero-copy checks, and autograd gradients for elementwise add, multiply, and transpose.
+Invoke the tests with `cmake --build build --target check`. The suite covers contiguity, CPU arithmetic, safe division masking, sum and mean parity on CPU and Metal, command-queue pooling, multi-device CPU↔Metal↔CPU transfers, mixed CPU→Metal→CPU→Metal sequences, multi-threaded large tensor moves, profiling log validation with matching alloc/free counts, silent behaviour when `ORCHARD_TENSOR_PROFILE` is unset, alignment and zero-copy checks, and autograd gradients for elementwise add, multiply, and transpose.
 CPU-only configurations also run transpose, matmul, mean, and sum backward tests so gradients remain verified without Metal.
 
 ## Milestones
@@ -55,7 +55,7 @@ CPU-only configurations also run transpose, matmul, mean, and sum backward tests
 
 ## Contributor Protocol
 - Study `../AGENTS.md` before changing any source, test, or documentation file; it governs every operation in this repository.
-- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target test` from the repository root prior to committing, and capture any failure output.
+- Run `cmake -S . -B build -G Ninja` and `cmake --build build --target check` from the repository root prior to committing, and capture any failure output.
 - When profiling tests modify `ORCHARD_TENSOR_PROFILE`, call `tensor_profile_reset` after each change and remove stale logs with `tensor_profile_clear_log`.
 - Use `rg` to search for symbols; avoid recursive `ls` or `grep` invocations.
 - Format C++20 and Objective-C++ code with `clang-format` and keep lines concise.

--- a/metal-tensor/docs/design_spec_tensor_v0.md
+++ b/metal-tensor/docs/design_spec_tensor_v0.md
@@ -29,7 +29,7 @@
 ### 7. Validation Matrix & Testing Strategy
 - Unit tests live under `metal-tensor/tests/` and use a vendored copy of GoogleTest under `third_party/googletest`. They verify zero-copy `to("cpu")`, slice/view mutation coherence, clone storage independence, data pointer alignment, and allocator stress with 100 k alloc/free cycles.
 - Fuzz tests and race-condition tests (planned) will exercise random shape/stride transformations and multi-threaded reference counting. Any imbalance or lock misuse fails the suite to keep concurrency bugs from creeping in.
-- Before every pull request, run `cmake --build build --target test` on a configured build tree and capture success or failure in the pull request description.
+- Before every pull request, run `cmake --build build --target check` on a configured build tree and capture success or failure in the pull request description.
 
 ### 8. Instrumentation & Profiling Hooks
 - When compiled with `ORCHARD_PROFILE_ALLOC`, every allocation logs its UUID, shape, dtype, and device to `/tmp/orchard_tensor_profile.log`. These logs feed directly into Instruments or custom analysis scripts for leak tracking.


### PR DESCRIPTION
## Summary
- Replace `--target test` with `--target check` across documentation and helper scripts so tests build before running
- Ensure bootstrap script builds and runs tests using the `check` target
- Pass `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` in the bootstrap script to keep local and remote builds offline

## Testing
- `cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_689f58d0e940832ebabc406df2e26eb8