### PR TITLE
Guard MetalContext and wrap os_unfair_lock

### DIFF
--- a/metal-tensor/metal/core/tensor/Tensor.cpp
+++ b/metal-tensor/metal/core/tensor/Tensor.cpp
@@ -136,7 +136,7 @@ Tensor::Tensor(const Tensor &other) {
   if (other.impl_) {
     impl_ = new TensorImpl(*other.impl_);
     if (impl_->storage) {
-      std::lock_guard guard(other.impl_->lock);
+      std::lock_guard<TensorLock> guard(other.impl_->lock);
       impl_->storage->retain();
     }
   }
@@ -151,7 +151,7 @@ Tensor &Tensor::operator=(const Tensor &other) {
     return *this;
   if (impl_) {
     if (impl_->storage) {
-      std::lock_guard guard(impl_->lock);
+      std::lock_guard<TensorLock> guard(impl_->lock);
       impl_->storage->release();
     }
     delete impl_;
@@ -160,7 +160,7 @@ Tensor &Tensor::operator=(const Tensor &other) {
   if (other.impl_) {
     impl_ = new TensorImpl(*other.impl_);
     if (impl_->storage) {
-      std::lock_guard guard(other.impl_->lock);
+      std::lock_guard<TensorLock> guard(other.impl_->lock);
       impl_->storage->retain();
     }
   }
@@ -185,7 +185,7 @@ Tensor::Tensor(Tensor &&other) noexcept
 Tensor &Tensor::operator=(Tensor &&other) noexcept {
   if (this != &other) {
     if (impl_ && impl_->storage) {
-      std::lock_guard guard(impl_->lock);
+      std::lock_guard<TensorLock> guard(impl_->lock);
       impl_->storage->release();
       delete impl_;
     }
@@ -204,7 +204,7 @@ Tensor &Tensor::operator=(Tensor &&other) noexcept {
 Tensor::~Tensor() {
   if (impl_) {
     if (impl_->storage) {
-      std::lock_guard guard(impl_->lock);
+      std::lock_guard<TensorLock> guard(impl_->lock);
       impl_->storage->release();
     }
     delete impl_;
@@ -273,7 +273,7 @@ Tensor Tensor::view(const std::array<std::int64_t, 8> &newShape) const {
     return Tensor{};
   auto *impl = new TensorImpl{};
   {
-    std::lock_guard guard(this->impl_->lock);
+    std::lock_guard<TensorLock> guard(this->impl_->lock);
     this->impl_->storage->retain();
   }
   impl->storage = this->impl_->storage;
@@ -300,7 +300,7 @@ Tensor Tensor::transpose(int dim0, int dim1) const {
     return Tensor{};
   auto *impl = new TensorImpl{};
   {
-    std::lock_guard guard(this->impl_->lock);
+    std::lock_guard<TensorLock> guard(this->impl_->lock);
     this->impl_->storage->retain();
   }
   impl->storage = this->impl_->storage;
@@ -339,7 +339,7 @@ Tensor Tensor::slice(int dim, int start, int end, int step) const {
 
   auto *impl = new TensorImpl{};
   {
-    std::lock_guard guard(this->impl_->lock);
+    std::lock_guard<TensorLock> guard(this->impl_->lock);
     this->impl_->storage->retain();
   }
   impl->storage = this->impl_->storage;
@@ -360,7 +360,7 @@ Tensor Tensor::to(Device dev) const {
   if (dev == impl_->device) {
     auto *impl = new TensorImpl{};
     {
-      std::lock_guard guard(this->impl_->lock);
+      std::lock_guard<TensorLock> guard(this->impl_->lock);
       this->impl_->storage->retain();
     }
     impl->storage = this->impl_->storage;
@@ -418,7 +418,7 @@ Tensor Tensor::contiguous() const {
   if (is_contiguous()) {
     auto *impl = new TensorImpl{};
     {
-      std::lock_guard guard(this->impl_->lock);
+      std::lock_guard<TensorLock> guard(this->impl_->lock);
       this->impl_->storage->retain();
     }
     impl->storage = this->impl_->storage;

--- a/metal-tensor/metal/core/tensor/TensorImpl.h
+++ b/metal-tensor/metal/core/tensor/TensorImpl.h
@@ -4,8 +4,15 @@
 #include <cstddef>
 #ifdef __APPLE__
 #include <os/lock.h>
+struct UnfairLock {
+  os_unfair_lock l = OS_UNFAIR_LOCK_INIT;
+  void lock() { os_unfair_lock_lock(&l); }
+  void unlock() { os_unfair_lock_unlock(&l); }
+};
+using TensorLock = UnfairLock;
 #else
 #include <mutex>
+using TensorLock = std::mutex;
 #endif
 
 #include "Storage.h"
@@ -19,11 +26,7 @@ struct TensorImpl {
   DType dtype{DType::f32};
   Device device{Device::cpu};
   std::int64_t offset{0};
-#ifdef __APPLE__
-  os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
-#else
-  std::mutex lock;
-#endif
+  TensorLock lock;
   void *grad_fn{nullptr};
   void *grad_ctx{nullptr};
 

--- a/metal-tensor/metal/runtime/MetalContext.h
+++ b/metal-tensor/metal/runtime/MetalContext.h
@@ -8,12 +8,14 @@
 
 #include <vector>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__OBJC__)
 #include <Metal/Metal.h>
+using MTLDeviceRef = id<MTLDevice>;
 using MTLCommandQueueRef = id<MTLCommandQueue>;
 using MTLCommandBufferRef = id<MTLCommandBuffer>;
 using MTLBlitCommandEncoderRef = id<MTLBlitCommandEncoder>;
 #else
+using MTLDeviceRef = void *;
 using MTLCommandQueueRef = void *;
 using MTLCommandBufferRef = void *;
 using MTLBlitCommandEncoderRef = void *;
@@ -25,9 +27,9 @@ class MetalContext {
 public:
   MetalContext();
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__OBJC__)
   /// Returns the underlying MTLDevice.
-  id<MTLDevice> device() const { return device_; }
+  MTLDeviceRef device() const { return device_; }
 #endif
 
   /// Acquire a command queue for the current thread.
@@ -43,10 +45,12 @@ public:
                                                 MTLCommandBufferRef &cmdBuf);
 
 private:
-#ifdef __APPLE__
-  id<MTLDevice> device_ = nil;
-  std::vector<MTLCommandQueueRef> queue_pool_;
+#if defined(__APPLE__) && defined(__OBJC__)
+  MTLDeviceRef device_ = nil;
+#else
+  MTLDeviceRef device_ = nullptr;
 #endif
+  std::vector<MTLCommandQueueRef> queue_pool_;
 };
 
 /// Obtain the Metal context associated with the calling thread.
@@ -56,14 +60,14 @@ MetalContext &metal_context();
 
 // Inline implementations
 inline orchard::runtime::MetalContext::MetalContext() {
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__OBJC__)
   device_ = MTLCreateSystemDefaultDevice();
 #endif
 }
 
 inline MTLCommandQueueRef
 orchard::runtime::MetalContext::acquire_command_queue() {
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__OBJC__)
   if (!queue_pool_.empty()) {
     id<MTLCommandQueue> queue = queue_pool_.back();
     queue_pool_.pop_back();
@@ -77,7 +81,7 @@ orchard::runtime::MetalContext::acquire_command_queue() {
 
 inline void
 orchard::runtime::MetalContext::return_command_queue(MTLCommandQueueRef queue) {
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__OBJC__)
   if (queue)
     queue_pool_.push_back(queue);
 #else
@@ -88,7 +92,7 @@ orchard::runtime::MetalContext::return_command_queue(MTLCommandQueueRef queue) {
 inline MTLBlitCommandEncoderRef
 orchard::runtime::MetalContext::acquire_blit_encoder(
     MTLCommandQueueRef &queue, MTLCommandBufferRef &cmdBuf) {
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__OBJC__)
   queue = acquire_command_queue();
   cmdBuf = [queue commandBuffer];
   return [cmdBuf blitCommandEncoder];

--- a/metal-tensor/metal/runtime/MetalKernels.mm
+++ b/metal-tensor/metal/runtime/MetalKernels.mm
@@ -370,18 +370,6 @@ void metal_div_backward_b(const float *g, const float *a, const float *b,
   ctx.return_command_queue(queue);
 }
 
-void metal_div_backward_a(const float *g, const float *b, float *ga,
-                          std::size_t n) {
-  for (std::size_t i = 0; i < n; ++i)
-    ga[i] = g[i] / b[i];
-}
-
-void metal_div_backward_b(const float *g, const float *a, const float *b,
-                          float *gb, std::size_t n) {
-  for (std::size_t i = 0; i < n; ++i)
-    gb[i] = -g[i] * a[i] / (b[i] * b[i]);
-}
-
 void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
                   std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
@@ -766,6 +754,21 @@ void metal_mean_axis(const float *a, float *out, const std::int64_t *shape,
   [strideBuf release];
   ctx.return_command_queue(queue);
 }
+
+#else
+
+void metal_div_backward_a(const float *g, const float *b, float *ga,
+                          std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    ga[i] = g[i] / b[i];
+}
+
+void metal_div_backward_b(const float *g, const float *a, const float *b,
+                          float *gb, std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    gb[i] = -g[i] * a[i] / (b[i] * b[i]);
+}
+
 #endif
 
 } // namespace orchard::runtime

--- a/metal-tensor/metal/runtime/runtime.mm
+++ b/metal-tensor/metal/runtime/runtime.mm
@@ -43,7 +43,11 @@ void metal_copy_buffers(void *dstBuf, void *srcBuf, std::size_t bytes) {
   id<MTLBlitCommandEncoder> blit = ctx.acquire_blit_encoder(queue, cmd);
   id<MTLBuffer> dst = (__bridge id<MTLBuffer>)dstBuf;
   id<MTLBuffer> src = (__bridge id<MTLBuffer>)srcBuf;
-  [blit copyFromBuffer:src sourceOffset:0 toBuffer:dst destOffset:0 size:bytes];
+  [blit copyFromBuffer:src
+           sourceOffset:0
+               toBuffer:dst
+      destinationOffset:0
+                   size:bytes];
   [blit endEncoding];
   [cmd commit];
   [cmd waitUntilCompleted];
@@ -60,7 +64,11 @@ void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes) {
   id<MTLCommandQueue> queue = nil;
   id<MTLCommandBuffer> cmd = nil;
   id<MTLBlitCommandEncoder> blit = ctx.acquire_blit_encoder(queue, cmd);
-  [blit copyFromBuffer:tmp sourceOffset:0 toBuffer:dst destOffset:0 size:bytes];
+  [blit copyFromBuffer:tmp
+           sourceOffset:0
+               toBuffer:dst
+      destinationOffset:0
+                   size:bytes];
   [blit endEncoding];
   [cmd commit];
   [cmd waitUntilCompleted];
@@ -79,7 +87,11 @@ void metal_copy_metal_to_cpu(void *dst, void *srcBuf, std::size_t bytes) {
   id<MTLCommandQueue> queue = nil;
   id<MTLCommandBuffer> cmd = nil;
   id<MTLBlitCommandEncoder> blit = ctx.acquire_blit_encoder(queue, cmd);
-  [blit copyFromBuffer:src sourceOffset:0 toBuffer:tmp destOffset:0 size:bytes];
+  [blit copyFromBuffer:src
+           sourceOffset:0
+               toBuffer:tmp
+      destinationOffset:0
+                   size:bytes];
   [blit endEncoding];
   [cmd commit];
   [cmd waitUntilCompleted];


### PR DESCRIPTION
## Summary
- Include `<Metal/Metal.h>` only when building ObjC++ on Apple platforms
- Fall back to opaque `void*` handles for device and queue pools in pure C++
- Wrap `os_unfair_lock` in a lockable helper and guard tensor state with `std::lock_guard`
- Compile Metal div backward kernels only on Apple and provide CPU fallbacks otherwise
- Call `copyFromBuffer` with the correct `destinationOffset:` selector

## Testing
- `cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_689f6c59ae28832e8092861817cabbe8