### PR TITLE
Guard uuid linkage and prune redundant links

### DIFF
--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -15,7 +15,9 @@ add_library(orchard_core STATIC
 )
 
 target_include_directories(orchard_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/metal)
-target_link_libraries(orchard_core PUBLIC uuid)
+if(NOT APPLE)
+  target_link_libraries(orchard_core PUBLIC uuid)
+endif()
 
 add_library(orchard_metal STATIC)
 
@@ -35,7 +37,7 @@ else()
 endif()
 
 target_include_directories(orchard_metal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/metal)
-target_link_libraries(orchard_metal PUBLIC orchard_core)
+target_link_libraries(orchard_metal PRIVATE orchard_core)
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/metal-tensor/metal/runtime/MetalContext.h
+++ b/metal-tensor/metal/runtime/MetalContext.h
@@ -47,10 +47,11 @@ public:
 private:
 #if defined(__APPLE__) && defined(__OBJC__)
   MTLDeviceRef device_ = nil;
-#else
-  MTLDeviceRef device_ = nullptr;
-#endif
   std::vector<MTLCommandQueueRef> queue_pool_;
+#else
+  [[maybe_unused]] MTLDeviceRef device_ = nullptr;
+  [[maybe_unused]] std::vector<MTLCommandQueueRef> queue_pool_;
+#endif
 };
 
 /// Obtain the Metal context associated with the calling thread.


### PR DESCRIPTION
## Summary
- avoid linking uuid on Apple platforms
- mark unused MetalContext members for non-Objective-C builds
- make orchard_metal depend privately on orchard_core to prevent duplicate linkage

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target check`

------
https://chatgpt.com/codex/tasks/task_e_689f9939c140832eb95603c669852887