### PR TITLE
Link Metal libraries and streamline test linkage

### DIFF
--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -18,6 +18,9 @@ target_include_directories(orchard_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/metal
 if(NOT APPLE)
   target_link_libraries(orchard_core PUBLIC uuid)
 endif()
+if(APPLE)
+  target_link_libraries(orchard_core PUBLIC "-framework Accelerate")
+endif()
 
 add_library(orchard_metal STATIC)
 
@@ -37,7 +40,13 @@ else()
 endif()
 
 target_include_directories(orchard_metal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/metal)
-target_link_libraries(orchard_metal PRIVATE orchard_core)
+target_link_libraries(orchard_metal PUBLIC orchard_core)
+if(APPLE)
+  target_link_libraries(orchard_metal PUBLIC Metal::Metal objc)
+endif()
+
+# Resolve cross-library references when only linking orchard_metal.
+target_link_libraries(orchard_core PUBLIC orchard_metal)
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/metal-tensor/tests/CMakeLists.txt
+++ b/metal-tensor/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 add_executable(metal_tensor_tests tensor_tests.cpp multi_device_tests.cpp)
 
-target_link_libraries(metal_tensor_tests PRIVATE ${GTEST_LIB} orchard_core orchard_metal)
+target_link_libraries(metal_tensor_tests PRIVATE ${GTEST_LIB} orchard_metal)
 
 target_compile_features(metal_tensor_tests PRIVATE cxx_std_20)
 


### PR DESCRIPTION
## Summary
- Link `orchard_core` against Accelerate on Apple
- Expose Metal and Objective-C runtime frameworks to dependents
- Simplify test linkage by relying on `orchard_metal`'s public requirements

## Testing
- `cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_689fb0d930dc832ebbf5a7370772a404