### PR TITLE
Load custom Metal module and use APPLE checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+if(APPLE)
   project(orchard LANGUAGES C CXX OBJCXX)
   find_package(Metal REQUIRED)
   link_libraries(Metal::Metal)
@@ -16,8 +18,6 @@ endif()
 
 option(ORCHARD_BUILD_EXPERIMENTAL "Build experimental PyTorch components" OFF)
 option(FETCHCONTENT_FULLY_DISCONNECTED "Disable FetchContent network access" OFF)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(CTest)
 
@@ -35,6 +35,6 @@ if(BUILD_TESTING AND TARGET metal_tensor_tests)
     DEPENDS metal_tensor_tests
   )
 endif()
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND ORCHARD_BUILD_EXPERIMENTAL)
+if(APPLE AND ORCHARD_BUILD_EXPERIMENTAL)
   add_subdirectory(experimental/orchard_ops)
 endif()

--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(orchard_metal STATIC)
 # Restrict Objective-C++ runtime to Apple hosts. runtime_cpu.cpp and
 # CpuKernels.cpp mirror the Metal entry points for CPU-only builds so no .mm
 # files are compiled.
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(APPLE)
   target_sources(orchard_metal PRIVATE
     metal/runtime/runtime.mm
     metal/runtime/MetalKernels.mm


### PR DESCRIPTION
## Summary
- load repository's `cmake` modules before invoking `find_package` so Metal stubs resolve
- replace Darwin string checks with `APPLE` to select Objective-C sources and experimental build correctly

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_689fed2ff4a0832e9932af3663c58b1d