### PR TITLE
Harden Metal runtime for missing devices

### DIFF
--- a/metal-tensor/CMakeLists.txt
+++ b/metal-tensor/CMakeLists.txt
@@ -47,7 +47,6 @@ if(APPLE)
 endif()
 
 # Resolve cross-library references when only linking orchard_metal.
-target_link_libraries(orchard_core PUBLIC orchard_metal)
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/metal-tensor/metal/core/autograd/Node.cpp
+++ b/metal-tensor/metal/core/autograd/Node.cpp
@@ -3,6 +3,8 @@
 #include "../../runtime/MetalKernels.h"
 #include "../tensor/Tensor.h"
 
+#include <cstdint>
+
 using namespace orchard::core::tensor;
 
 namespace orchard::core::autograd {
@@ -18,11 +20,17 @@ void Node::accumulate(Tensor &t, const Tensor &grad) {
   if (t.grad().device() == Device::mps) {
     auto shape = t.shape();
     auto strides = t.strides();
+    std::uint32_t dims = 0;
+    for (auto s : shape) {
+      if (s <= 0)
+        break;
+      ++dims;
+    }
     orchard::runtime::metal_add(static_cast<const float *>(grad.data_ptr()),
                                 static_cast<const float *>(t.grad().data_ptr()),
                                 static_cast<float *>(t.grad().data_ptr()),
                                 shape.data(), strides.data(), strides.data(),
-                                n);
+                                dims, n);
   } else {
     orchard::runtime::cpu_context().add(
         static_cast<const float *>(grad.data_ptr()),

--- a/metal-tensor/metal/core/tensor/Tensor.cpp
+++ b/metal-tensor/metal/core/tensor/Tensor.cpp
@@ -503,7 +503,8 @@ Tensor Tensor::add(const Tensor &other) const {
         static_cast<const float *>(other.impl_->storage->data) +
             other.impl_->offset,
         static_cast<float *>(out.impl_->storage->data) + out.impl_->offset,
-        info.shape.data(), info.a_strides.data(), info.b_strides.data(), n);
+        info.shape.data(), info.a_strides.data(), info.b_strides.data(),
+        static_cast<std::uint32_t>(rank_of(info.shape)), n);
   }
   out.set_requires_grad(requires_grad_ || other.requires_grad_);
   if (out.requires_grad())
@@ -533,7 +534,8 @@ Tensor Tensor::mul(const Tensor &other) const {
         static_cast<const float *>(other.impl_->storage->data) +
             other.impl_->offset,
         static_cast<float *>(out.impl_->storage->data) + out.impl_->offset,
-        info.shape.data(), info.a_strides.data(), info.b_strides.data(), n);
+        info.shape.data(), info.a_strides.data(), info.b_strides.data(),
+        static_cast<std::uint32_t>(rank_of(info.shape)), n);
   }
   bool rg = requires_grad_ || other.requires_grad_;
   out.set_requires_grad(rg);
@@ -589,8 +591,8 @@ Tensor Tensor::div(const Tensor &other, bool safe) const {
         static_cast<const float *>(other.impl_->storage->data) +
             other.impl_->offset,
         static_cast<float *>(out.impl_->storage->data) + out.impl_->offset,
-        info.shape.data(), info.a_strides.data(), info.b_strides.data(), n,
-        safe);
+        info.shape.data(), info.a_strides.data(), info.b_strides.data(),
+        static_cast<std::uint32_t>(rank_of(info.shape)), n, safe);
   }
   bool rg = requires_grad_ || other.requires_grad_;
   out.set_requires_grad(rg);
@@ -794,8 +796,8 @@ Tensor Tensor::sum(int dim, bool keepdim) const {
     runtime::metal_reduce_sum_axis(
         static_cast<const float *>(impl_->storage->data),
         static_cast<float *>(out.impl_->storage->data), outShape.data(),
-        impl_->strides.data(), static_cast<std::uint32_t>(axisLen),
-        static_cast<std::uint32_t>(dim),
+        impl_->strides.data(), static_cast<std::uint32_t>(rank_of(outShape)),
+        static_cast<std::uint32_t>(axisLen), static_cast<std::uint32_t>(dim),
         static_cast<std::size_t>(core::tensor::numel(outShape)));
   }
   out.set_requires_grad(requires_grad_);
@@ -854,8 +856,8 @@ Tensor Tensor::mean(int dim, bool keepdim) const {
     runtime::metal_mean_axis(
         static_cast<const float *>(impl_->storage->data),
         static_cast<float *>(out.impl_->storage->data), outShape.data(),
-        impl_->strides.data(), static_cast<std::uint32_t>(axisLen),
-        static_cast<std::uint32_t>(dim),
+        impl_->strides.data(), static_cast<std::uint32_t>(rank_of(outShape)),
+        static_cast<std::uint32_t>(axisLen), static_cast<std::uint32_t>(dim),
         static_cast<std::size_t>(core::tensor::numel(outShape)));
   }
   out.set_requires_grad(requires_grad_);

--- a/metal-tensor/metal/runtime/CpuKernels.cpp
+++ b/metal-tensor/metal/runtime/CpuKernels.cpp
@@ -2,24 +2,23 @@
 
 #include <array>
 #include <cstring>
+#include <vector>
 
 namespace orchard::runtime {
 
 void metal_add(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n) {
-  std::array<std::int64_t, 8> shp;
-  std::array<std::int64_t, 8> as;
-  std::array<std::int64_t, 8> bs;
-  std::memcpy(shp.data(), shape, sizeof(std::int64_t) * 8);
-  std::memcpy(as.data(), astrides, sizeof(std::int64_t) * 8);
-  std::memcpy(bs.data(), bstrides, sizeof(std::int64_t) * 8);
-  std::array<std::int64_t, 8> idx{};
+               const std::int64_t *bstrides, std::uint32_t dims,
+               std::size_t n) {
+  std::vector<std::int64_t> shp(shape, shape + dims);
+  std::vector<std::int64_t> as(astrides, astrides + dims);
+  std::vector<std::int64_t> bs(bstrides, bstrides + dims);
+  std::vector<std::int64_t> idx(dims);
   std::int64_t ao = 0;
   std::int64_t bo = 0;
   for (std::size_t i = 0; i < n; ++i) {
     c[i] = a[ao] + b[bo];
-    for (int d = 7; d >= 0; --d) {
+    for (int d = dims - 1; d >= 0; --d) {
       idx[d]++;
       ao += as[d];
       if (bs[d] != 0)
@@ -47,19 +46,17 @@ void metal_div_scalar(const float *a, float scalar, float *out, std::size_t n,
 
 void metal_mul(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n) {
-  std::array<std::int64_t, 8> shp;
-  std::array<std::int64_t, 8> as;
-  std::array<std::int64_t, 8> bs;
-  std::memcpy(shp.data(), shape, sizeof(std::int64_t) * 8);
-  std::memcpy(as.data(), astrides, sizeof(std::int64_t) * 8);
-  std::memcpy(bs.data(), bstrides, sizeof(std::int64_t) * 8);
-  std::array<std::int64_t, 8> idx{};
+               const std::int64_t *bstrides, std::uint32_t dims,
+               std::size_t n) {
+  std::vector<std::int64_t> shp(shape, shape + dims);
+  std::vector<std::int64_t> as(astrides, astrides + dims);
+  std::vector<std::int64_t> bs(bstrides, bstrides + dims);
+  std::vector<std::int64_t> idx(dims);
   std::int64_t ao = 0;
   std::int64_t bo = 0;
   for (std::size_t i = 0; i < n; ++i) {
     c[i] = a[ao] * b[bo];
-    for (int d = 7; d >= 0; --d) {
+    for (int d = dims - 1; d >= 0; --d) {
       idx[d]++;
       ao += as[d];
       if (bs[d] != 0)
@@ -76,20 +73,18 @@ void metal_mul(const float *a, const float *b, float *c,
 
 void metal_div(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n, bool safe) {
-  std::array<std::int64_t, 8> shp;
-  std::array<std::int64_t, 8> as;
-  std::array<std::int64_t, 8> bs;
-  std::memcpy(shp.data(), shape, sizeof(std::int64_t) * 8);
-  std::memcpy(as.data(), astrides, sizeof(std::int64_t) * 8);
-  std::memcpy(bs.data(), bstrides, sizeof(std::int64_t) * 8);
-  std::array<std::int64_t, 8> idx{};
+               const std::int64_t *bstrides, std::uint32_t dims, std::size_t n,
+               bool safe) {
+  std::vector<std::int64_t> shp(shape, shape + dims);
+  std::vector<std::int64_t> as(astrides, astrides + dims);
+  std::vector<std::int64_t> bs(bstrides, bstrides + dims);
+  std::vector<std::int64_t> idx(dims);
   std::int64_t ao = 0;
   std::int64_t bo = 0;
   for (std::size_t i = 0; i < n; ++i) {
     float bv = b[bo];
     c[i] = (safe && bv == 0.0f) ? 0.0f : a[ao] / bv;
-    for (int d = 7; d >= 0; --d) {
+    for (int d = dims - 1; d >= 0; --d) {
       idx[d]++;
       ao += as[d];
       if (bs[d] != 0)
@@ -156,16 +151,15 @@ void metal_mean(const float *a, float *out, std::size_t n) {
 
 void metal_reduce_sum_axis(const float *a, float *out,
                            const std::int64_t *shape,
-                           const std::int64_t *strides, std::uint32_t axis_len,
-                           std::uint32_t axis, std::size_t n) {
-  std::array<std::int64_t, 8> shp;
-  std::array<std::int64_t, 8> st;
-  std::memcpy(shp.data(), shape, sizeof(std::int64_t) * 8);
-  std::memcpy(st.data(), strides, sizeof(std::int64_t) * 8);
+                           const std::int64_t *strides, std::uint32_t dims,
+                           std::uint32_t axis_len, std::uint32_t axis,
+                           std::size_t n) {
+  std::vector<std::int64_t> shp(shape, shape + dims);
+  std::vector<std::int64_t> st(strides, strides + dims);
   for (std::size_t i = 0; i < n; ++i) {
     std::size_t idx = i;
     long base = 0;
-    for (int d = 7; d >= 0; --d) {
+    for (int d = dims - 1; d >= 0; --d) {
       long s = shp[d];
       long coord = idx % s;
       idx /= s;
@@ -182,16 +176,15 @@ void metal_reduce_sum_axis(const float *a, float *out,
 }
 
 void metal_mean_axis(const float *a, float *out, const std::int64_t *shape,
-                     const std::int64_t *strides, std::uint32_t axis_len,
-                     std::uint32_t axis, std::size_t n) {
-  std::array<std::int64_t, 8> shp;
-  std::array<std::int64_t, 8> st;
-  std::memcpy(shp.data(), shape, sizeof(std::int64_t) * 8);
-  std::memcpy(st.data(), strides, sizeof(std::int64_t) * 8);
+                     const std::int64_t *strides, std::uint32_t dims,
+                     std::uint32_t axis_len, std::uint32_t axis,
+                     std::size_t n) {
+  std::vector<std::int64_t> shp(shape, shape + dims);
+  std::vector<std::int64_t> st(strides, strides + dims);
   for (std::size_t i = 0; i < n; ++i) {
     std::size_t idx = i;
     long base = 0;
-    for (int d = 7; d >= 0; --d) {
+    for (int d = dims - 1; d >= 0; --d) {
       long s = shp[d];
       long coord = idx % s;
       idx /= s;

--- a/metal-tensor/metal/runtime/MetalContext.h
+++ b/metal-tensor/metal/runtime/MetalContext.h
@@ -29,7 +29,8 @@ public:
 
 #if defined(__APPLE__) && defined(__OBJC__)
   /// Returns the underlying MTLDevice.
-  MTLDeviceRef device() const { return device_; }
+  MTLDeviceRef device() const { return has_device_ ? device_ : nil; }
+  bool has_device() const { return has_device_; }
 #endif
 
   /// Acquire a command queue for the current thread.
@@ -47,9 +48,11 @@ public:
 private:
 #if defined(__APPLE__) && defined(__OBJC__)
   MTLDeviceRef device_ = nil;
+  bool has_device_ = false;
   std::vector<MTLCommandQueueRef> queue_pool_;
 #else
   [[maybe_unused]] MTLDeviceRef device_ = nullptr;
+  [[maybe_unused]] bool has_device_ = false;
   [[maybe_unused]] std::vector<MTLCommandQueueRef> queue_pool_;
 #endif
 };
@@ -63,18 +66,21 @@ MetalContext &metal_context();
 inline orchard::runtime::MetalContext::MetalContext() {
 #if defined(__APPLE__) && defined(__OBJC__)
   device_ = MTLCreateSystemDefaultDevice();
+  has_device_ = device_ != nil;
 #endif
 }
 
 inline MTLCommandQueueRef
 orchard::runtime::MetalContext::acquire_command_queue() {
 #if defined(__APPLE__) && defined(__OBJC__)
+  if (!has_device_)
+    return nil;
   if (!queue_pool_.empty()) {
     id<MTLCommandQueue> queue = queue_pool_.back();
     queue_pool_.pop_back();
     return queue;
   }
-  return [device_ newCommandQueue];
+  return has_device_ ? [device_ newCommandQueue] : nil;
 #else
   return nullptr;
 #endif
@@ -83,7 +89,7 @@ orchard::runtime::MetalContext::acquire_command_queue() {
 inline void
 orchard::runtime::MetalContext::return_command_queue(MTLCommandQueueRef queue) {
 #if defined(__APPLE__) && defined(__OBJC__)
-  if (queue)
+  if (has_device_ && queue)
     queue_pool_.push_back(queue);
 #else
   (void)queue;
@@ -94,6 +100,11 @@ inline MTLBlitCommandEncoderRef
 orchard::runtime::MetalContext::acquire_blit_encoder(
     MTLCommandQueueRef &queue, MTLCommandBufferRef &cmdBuf) {
 #if defined(__APPLE__) && defined(__OBJC__)
+  if (!has_device_) {
+    queue = nil;
+    cmdBuf = nil;
+    return nil;
+  }
   queue = acquire_command_queue();
   cmdBuf = [queue commandBuffer];
   return [cmdBuf blitCommandEncoder];

--- a/metal-tensor/metal/runtime/MetalKernels.h
+++ b/metal-tensor/metal/runtime/MetalKernels.h
@@ -6,13 +6,14 @@
 namespace orchard::runtime {
 void metal_add(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n);
+               const std::int64_t *bstrides, std::uint32_t dims, std::size_t n);
 void metal_mul(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n);
+               const std::int64_t *bstrides, std::uint32_t dims, std::size_t n);
 void metal_div(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n, bool safe);
+               const std::int64_t *bstrides, std::uint32_t dims, std::size_t n,
+               bool safe);
 void metal_div_scalar(const float *a, float scalar, float *out, std::size_t n,
                       bool safe);
 void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
@@ -21,11 +22,12 @@ void metal_reduce_sum(const float *a, float *out, std::size_t n);
 void metal_mean(const float *a, float *out, std::size_t n);
 void metal_reduce_sum_axis(const float *a, float *out,
                            const std::int64_t *shape,
-                           const std::int64_t *strides, std::uint32_t axis_len,
-                           std::uint32_t axis, std::size_t n);
+                           const std::int64_t *strides, std::uint32_t dims,
+                           std::uint32_t axis_len, std::uint32_t axis,
+                           std::size_t n);
 void metal_mean_axis(const float *a, float *out, const std::int64_t *shape,
-                     const std::int64_t *strides, std::uint32_t axis_len,
-                     std::uint32_t axis, std::size_t n);
+                     const std::int64_t *strides, std::uint32_t dims,
+                     std::uint32_t axis_len, std::uint32_t axis, std::size_t n);
 void metal_mul_backward_a(const float *g, const float *b, float *ga,
                           std::size_t n);
 void metal_mul_backward_b(const float *g, const float *a, float *gb,

--- a/metal-tensor/metal/runtime/MetalKernels.mm
+++ b/metal-tensor/metal/runtime/MetalKernels.mm
@@ -29,9 +29,12 @@ std::string load_kernel_src(const char *file) {
 #ifdef __APPLE__
 void metal_add(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n) {
+               const std::int64_t *bstrides, std::uint32_t dims,
+               std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("add.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -41,11 +44,24 @@ void metal_add(const float *a, const float *b, float *c,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "add.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"add_arrays"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "add pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -56,15 +72,15 @@ void metal_add(const float *a, const float *b, float *c,
   [enc setBuffer:(__bridge id<MTLBuffer>)c offset:0 atIndex:2];
   id<MTLBuffer> shapeBuf =
       [ctx.device() newBufferWithBytes:shape
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> aBuf =
       [ctx.device() newBufferWithBytes:astrides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> bBuf =
       [ctx.device() newBufferWithBytes:bstrides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   [enc setBuffer:shapeBuf offset:0 atIndex:3];
   [enc setBuffer:aBuf offset:0 atIndex:4];
@@ -83,9 +99,12 @@ void metal_add(const float *a, const float *b, float *c,
 
 void metal_mul(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n) {
+               const std::int64_t *bstrides, std::uint32_t dims,
+               std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("mul.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -95,11 +114,24 @@ void metal_mul(const float *a, const float *b, float *c,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "mul.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"mul_arrays"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "mul pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -110,15 +142,15 @@ void metal_mul(const float *a, const float *b, float *c,
   [enc setBuffer:(__bridge id<MTLBuffer>)c offset:0 atIndex:2];
   id<MTLBuffer> shapeBuf =
       [ctx.device() newBufferWithBytes:shape
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> aBuf =
       [ctx.device() newBufferWithBytes:astrides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> bBuf =
       [ctx.device() newBufferWithBytes:bstrides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   [enc setBuffer:shapeBuf offset:0 atIndex:3];
   [enc setBuffer:aBuf offset:0 atIndex:4];
@@ -136,9 +168,12 @@ void metal_mul(const float *a, const float *b, float *c,
 }
 void metal_div(const float *a, const float *b, float *c,
                const std::int64_t *shape, const std::int64_t *astrides,
-               const std::int64_t *bstrides, std::size_t n, bool safe) {
+               const std::int64_t *bstrides, std::uint32_t dims, std::size_t n,
+               bool safe) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("div.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -148,11 +183,24 @@ void metal_div(const float *a, const float *b, float *c,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "div.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"div_arrays"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "div pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -163,15 +211,15 @@ void metal_div(const float *a, const float *b, float *c,
   [enc setBuffer:(__bridge id<MTLBuffer>)c offset:0 atIndex:2];
   id<MTLBuffer> shapeBuf =
       [ctx.device() newBufferWithBytes:shape
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> aBuf =
       [ctx.device() newBufferWithBytes:astrides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> bBuf =
       [ctx.device() newBufferWithBytes:bstrides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   [enc setBuffer:shapeBuf offset:0 atIndex:3];
   [enc setBuffer:aBuf offset:0 atIndex:4];
@@ -194,6 +242,8 @@ void metal_div_scalar(const float *a, float scalar, float *out, std::size_t n,
                       bool safe) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("div.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -203,11 +253,24 @@ void metal_div_scalar(const float *a, float scalar, float *out, std::size_t n,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "div.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"div_scalar"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "div_scalar pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -300,6 +363,8 @@ void metal_div_backward_a(const float *g, const float *b, float *ga,
                           std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("div.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -309,11 +374,24 @@ void metal_div_backward_a(const float *g, const float *b, float *ga,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "div.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"div_backward_a"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "div_backward_a pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -335,6 +413,8 @@ void metal_div_backward_b(const float *g, const float *a, const float *b,
                           float *gb, std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("div.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -344,11 +424,24 @@ void metal_div_backward_b(const float *g, const float *a, const float *b,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "div.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"div_backward_b"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "div_backward_b pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -371,6 +464,8 @@ void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
                   std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("matmul.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -380,11 +475,24 @@ void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "matmul.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"matmul_kernel"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "matmul pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -411,6 +519,8 @@ void metal_matmul(const float *a, const float *b, float *c, std::size_t m,
 void metal_reduce_sum(const float *a, float *out, std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("reduce_sum.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -420,11 +530,24 @@ void metal_reduce_sum(const float *a, float *out, std::size_t n) {
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "reduce_sum.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"reduce_sum"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "reduce_sum pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -446,6 +569,8 @@ void metal_reduce_sum(const float *a, float *out, std::size_t n) {
 void metal_mean(const float *a, float *out, std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("mean.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -455,11 +580,24 @@ void metal_mean(const float *a, float *out, std::size_t n) {
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "mean.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"mean"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "mean pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -483,6 +621,8 @@ void metal_matmul_backward_a(const float *g, const float *b, float *ga,
                              std::size_t m, std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("matmul_backward.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -492,11 +632,24 @@ void metal_matmul_backward_a(const float *g, const float *b, float *ga,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "matmul_backward.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"matmul_backward_a"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "matmul_backward_a pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -525,6 +678,8 @@ void metal_matmul_backward_b(const float *g, const float *a, float *gb,
                              std::size_t m, std::size_t n, std::size_t k) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("matmul_backward.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -534,11 +689,24 @@ void metal_matmul_backward_b(const float *g, const float *a, float *gb,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "matmul_backward.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"matmul_backward_b"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "matmul_backward_b pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -566,6 +734,8 @@ void metal_transpose_backward(const float *g, float *out, std::size_t m,
                               std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("transpose_backward.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -575,11 +745,24 @@ void metal_transpose_backward(const float *g, float *out, std::size_t m,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "transpose_backward.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"transpose_backward"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "transpose_backward pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -603,6 +786,8 @@ void metal_transpose_backward(const float *g, float *out, std::size_t m,
 void metal_fill(float *out, float value, std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("fill.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -612,11 +797,24 @@ void metal_fill(float *out, float value, std::size_t n) {
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "fill.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"fill_value"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "fill pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -637,10 +835,13 @@ void metal_fill(float *out, float value, std::size_t n) {
 
 void metal_reduce_sum_axis(const float *a, float *out,
                            const std::int64_t *shape,
-                           const std::int64_t *strides, std::uint32_t axis_len,
-                           std::uint32_t axis, std::size_t n) {
+                           const std::int64_t *strides, std::uint32_t dims,
+                           std::uint32_t axis_len, std::uint32_t axis,
+                           std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("reduce_sum_axis.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -650,11 +851,24 @@ void metal_reduce_sum_axis(const float *a, float *out,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "reduce_sum_axis.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"reduce_sum_axis"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "reduce_sum_axis pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -664,11 +878,11 @@ void metal_reduce_sum_axis(const float *a, float *out,
   [enc setBuffer:(__bridge id<MTLBuffer>)out offset:0 atIndex:1];
   id<MTLBuffer> shapeBuf =
       [ctx.device() newBufferWithBytes:shape
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> strideBuf =
       [ctx.device() newBufferWithBytes:strides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   [enc setBuffer:shapeBuf offset:0 atIndex:2];
   [enc setBuffer:strideBuf offset:0 atIndex:3];
@@ -686,10 +900,13 @@ void metal_reduce_sum_axis(const float *a, float *out,
 }
 
 void metal_mean_axis(const float *a, float *out, const std::int64_t *shape,
-                     const std::int64_t *strides, std::uint32_t axis_len,
-                     std::uint32_t axis, std::size_t n) {
+                     const std::int64_t *strides, std::uint32_t dims,
+                     std::uint32_t axis_len, std::uint32_t axis,
+                     std::size_t n) {
   static id<MTLComputePipelineState> pipeline = nil;
   MetalContext &ctx = metal_context();
+  if (!ctx.device())
+    throw std::runtime_error("Metal device unavailable");
   if (!pipeline) {
     std::string src = load_kernel_src("mean_axis.metal");
     NSString *nsSrc = [[NSString alloc] initWithBytes:src.data()
@@ -699,11 +916,24 @@ void metal_mean_axis(const float *a, float *out, const std::int64_t *shape,
     id<MTLLibrary> lib = [ctx.device() newLibraryWithSource:nsSrc
                                                     options:nil
                                                       error:&err];
-    [nsSrc release];
+    if (err || !lib) {
+      std::string msg = "mean_axis.metal: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      [nsSrc release];
+      throw std::runtime_error(msg);
+    }
     id<MTLFunction> fn = [lib newFunctionWithName:@"mean_axis"];
     pipeline = [ctx.device() newComputePipelineStateWithFunction:fn error:&err];
     [fn release];
     [lib release];
+    if (err || !pipeline) {
+      std::string msg = "mean_axis pipeline: ";
+      if (err)
+        msg += [[err localizedDescription] UTF8String];
+      throw std::runtime_error(msg);
+    }
+    [nsSrc release];
   }
   id<MTLCommandQueue> queue = ctx.acquire_command_queue();
   id<MTLCommandBuffer> cmd = [queue commandBuffer];
@@ -713,11 +943,11 @@ void metal_mean_axis(const float *a, float *out, const std::int64_t *shape,
   [enc setBuffer:(__bridge id<MTLBuffer>)out offset:0 atIndex:1];
   id<MTLBuffer> shapeBuf =
       [ctx.device() newBufferWithBytes:shape
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   id<MTLBuffer> strideBuf =
       [ctx.device() newBufferWithBytes:strides
-                                length:sizeof(std::int64_t) * 8
+                                length:sizeof(std::int64_t) * dims
                                options:MTLResourceStorageModeShared];
   [enc setBuffer:shapeBuf offset:0 atIndex:2];
   [enc setBuffer:strideBuf offset:0 atIndex:3];

--- a/metal-tensor/tests/CMakeLists.txt
+++ b/metal-tensor/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 add_executable(metal_tensor_tests tensor_tests.cpp multi_device_tests.cpp)
 
-target_link_libraries(metal_tensor_tests PRIVATE ${GTEST_LIB} orchard_metal)
+target_link_libraries(metal_tensor_tests PRIVATE ${GTEST_LIB} orchard_core orchard_metal)
 
 target_compile_features(metal_tensor_tests PRIVATE cxx_std_20)
 


### PR DESCRIPTION
## Summary
- guard `MetalContext` against missing Metal devices and expose availability flags
- check Metal shader compilation errors and allocate shape metadata dynamically
- drop circular linkage and order test link for `orchard_core` and `orchard_metal`

## Testing
- `cmake -S . -B build -G Ninja -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
- `cmake --build build --target check --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68a0512c8af4832ea0fe4bd6efb0b459