### PR TITLE
Strengthen Metal copy helpers

### DIFF
--- a/metal-tensor/metal/core/tensor/Tensor.cpp
+++ b/metal-tensor/metal/core/tensor/Tensor.cpp
@@ -380,16 +380,23 @@ Tensor Tensor::to(Device dev) const {
       else if (impl_->device == Device::cpu && dev == Device::mps) {
         if (!aligned64(src.data_ptr()))
           return Tensor{};
-        orchard::runtime::metal_copy_cpu_to_metal(t.impl_->storage->data,
-                                                  src.data_ptr(), bytes);
+        orchard::runtime::metal_copy_cpu_to_metal(
+            static_cast<orchard::runtime::MTLBufferRef>(t.impl_->storage->data),
+            src.data_ptr(), bytes);
       } else if (impl_->device == Device::mps && dev == Device::cpu) {
         if (!aligned64(t.data_ptr()))
           return Tensor{};
         orchard::runtime::metal_copy_metal_to_cpu(
-            t.data_ptr(), src.impl_->storage->data, bytes);
+            t.data_ptr(),
+            static_cast<orchard::runtime::MTLBufferRef>(
+                src.impl_->storage->data),
+            bytes);
       } else if (impl_->device == Device::mps && dev == Device::mps) {
-        orchard::runtime::metal_copy_buffers(t.impl_->storage->data,
-                                             src.impl_->storage->data, bytes);
+        orchard::runtime::metal_copy_buffers(
+            static_cast<orchard::runtime::MTLBufferRef>(t.impl_->storage->data),
+            static_cast<orchard::runtime::MTLBufferRef>(
+                src.impl_->storage->data),
+            bytes);
       } else {
         std::memcpy(t.data_ptr(), src.data_ptr(), bytes);
       }

--- a/metal-tensor/metal/runtime/MetalContext.h
+++ b/metal-tensor/metal/runtime/MetalContext.h
@@ -1,12 +1,8 @@
-// MetalContext.h
-// -------------------------------------------------------------
-// Thin wrapper around the system default Metal device. Each thread
-// receives its own context instance which keeps a pool of command
-// queues for reuse.
-
 #pragma once
 
 #include <vector>
+
+namespace orchard::runtime {
 
 #if defined(__APPLE__) && defined(__OBJC__)
 #include <Metal/Metal.h>
@@ -14,108 +10,33 @@ using MTLDeviceRef = id<MTLDevice>;
 using MTLCommandQueueRef = id<MTLCommandQueue>;
 using MTLCommandBufferRef = id<MTLCommandBuffer>;
 using MTLBlitCommandEncoderRef = id<MTLBlitCommandEncoder>;
+using MTLBufferRef = id<MTLBuffer>;
 #else
 using MTLDeviceRef = void *;
 using MTLCommandQueueRef = void *;
 using MTLCommandBufferRef = void *;
 using MTLBlitCommandEncoderRef = void *;
+using MTLBufferRef = void *;
 #endif
-
-namespace orchard::runtime {
 
 class MetalContext {
 public:
   MetalContext();
 
-#if defined(__APPLE__) && defined(__OBJC__)
-  /// Returns the underlying MTLDevice.
-  MTLDeviceRef device() const { return device_missing_ ? nil : device_; }
-  bool has_device() const { return !device_missing_; }
-#endif
+  MTLDeviceRef device() const;
+  bool has_device() const;
 
-  /// Acquire a command queue for the current thread.
   MTLCommandQueueRef acquire_command_queue();
-
-  /// Return a command queue to the thread‑local pool.
   void return_command_queue(MTLCommandQueueRef queue);
-
-  /// Acquire a blit command encoder along with its backing queue and
-  /// command buffer. The caller is responsible for ending encoding,
-  /// committing the command buffer and returning the queue.
   MTLBlitCommandEncoderRef acquire_blit_encoder(MTLCommandQueueRef &queue,
                                                 MTLCommandBufferRef &cmdBuf);
 
 private:
-#if defined(__APPLE__) && defined(__OBJC__)
-  MTLDeviceRef device_ = nil;
-  bool device_missing_ = false;
+  MTLDeviceRef device_ = MTLDeviceRef{};
+  bool device_missing_ = true;
   std::vector<MTLCommandQueueRef> queue_pool_;
-#else
-  [[maybe_unused]] MTLDeviceRef device_ = nullptr;
-  [[maybe_unused]] bool device_missing_ = true;
-  [[maybe_unused]] std::vector<MTLCommandQueueRef> queue_pool_;
-#endif
 };
 
-/// Obtain the Metal context associated with the calling thread.
 MetalContext &metal_context();
 
 } // namespace orchard::runtime
-
-// Inline implementations
-inline orchard::runtime::MetalContext::MetalContext() {
-#if defined(__APPLE__) && defined(__OBJC__)
-  device_ = MTLCreateSystemDefaultDevice();
-  device_missing_ = device_ == nil;
-#endif
-}
-
-inline MTLCommandQueueRef
-orchard::runtime::MetalContext::acquire_command_queue() {
-#if defined(__APPLE__) && defined(__OBJC__)
-  if (device_missing_)
-    return nil;
-  if (!queue_pool_.empty()) {
-    id<MTLCommandQueue> queue = queue_pool_.back();
-    queue_pool_.pop_back();
-    return queue;
-  }
-  return device_missing_ ? nil : [device_ newCommandQueue];
-#else
-  return nullptr;
-#endif
-}
-
-inline void
-orchard::runtime::MetalContext::return_command_queue(MTLCommandQueueRef queue) {
-#if defined(__APPLE__) && defined(__OBJC__)
-  if (!device_missing_ && queue)
-    queue_pool_.push_back(queue);
-#else
-  (void)queue;
-#endif
-}
-
-inline MTLBlitCommandEncoderRef
-orchard::runtime::MetalContext::acquire_blit_encoder(
-    MTLCommandQueueRef &queue, MTLCommandBufferRef &cmdBuf) {
-#if defined(__APPLE__) && defined(__OBJC__)
-  if (device_missing_) {
-    queue = nil;
-    cmdBuf = nil;
-    return nil;
-  }
-  queue = acquire_command_queue();
-  cmdBuf = [queue commandBuffer];
-  return [cmdBuf blitCommandEncoder];
-#else
-  (void)queue;
-  (void)cmdBuf;
-  return nullptr;
-#endif
-}
-
-inline orchard::runtime::MetalContext &orchard::runtime::metal_context() {
-  thread_local MetalContext ctx;
-  return ctx;
-}

--- a/metal-tensor/metal/runtime/Runtime.h
+++ b/metal-tensor/metal/runtime/Runtime.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include "runtime/MetalContext.h"
 #include <cstddef>
 
 namespace orchard::runtime {
 
-void metal_copy_buffers(void *dstBuf, const void *srcBuf, std::size_t bytes);
-void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes);
-void metal_copy_metal_to_cpu(void *dst, const void *srcBuf, std::size_t bytes);
+void metal_copy_buffers(MTLBufferRef dstBuf, MTLBufferRef srcBuf,
+                        std::size_t bytes);
+void metal_copy_cpu_to_metal(MTLBufferRef dstBuf, const void *src,
+                             std::size_t bytes);
+void metal_copy_metal_to_cpu(void *dst, MTLBufferRef srcBuf, std::size_t bytes);
 
 } // namespace orchard::runtime

--- a/metal-tensor/metal/runtime/runtime.mm
+++ b/metal-tensor/metal/runtime/runtime.mm
@@ -8,6 +8,51 @@
 
 namespace orchard::runtime {
 
+MetalContext::MetalContext() {
+  device_ = MTLCreateSystemDefaultDevice();
+  device_missing_ = device_ == nil;
+}
+
+MTLDeviceRef MetalContext::device() const {
+  return device_missing_ ? nil : device_;
+}
+
+bool MetalContext::has_device() const { return !device_missing_; }
+
+MTLCommandQueueRef MetalContext::acquire_command_queue() {
+  if (device_missing_)
+    return nil;
+  if (!queue_pool_.empty()) {
+    id<MTLCommandQueue> queue = queue_pool_.back();
+    queue_pool_.pop_back();
+    return queue;
+  }
+  return [device_ newCommandQueue];
+}
+
+void MetalContext::return_command_queue(MTLCommandQueueRef queue) {
+  if (!device_missing_ && queue)
+    queue_pool_.push_back(queue);
+}
+
+MTLBlitCommandEncoderRef
+MetalContext::acquire_blit_encoder(MTLCommandQueueRef &queue,
+                                   MTLCommandBufferRef &cmdBuf) {
+  if (device_missing_) {
+    queue = nil;
+    cmdBuf = nil;
+    return nil;
+  }
+  queue = acquire_command_queue();
+  cmdBuf = [queue commandBuffer];
+  return [cmdBuf blitCommandEncoder];
+}
+
+MetalContext &metal_context() {
+  thread_local MetalContext ctx;
+  return ctx;
+}
+
 using ContextFactory = void *(*)();
 
 namespace {
@@ -38,15 +83,18 @@ void register_runtime_devices() {
 }
 
 #ifdef __APPLE__
-void metal_copy_buffers(void *dstBuf, const void *srcBuf, std::size_t bytes) {
+void metal_copy_buffers(MTLBufferRef dstBuf, MTLBufferRef srcBuf,
+                        std::size_t bytes) {
   MetalContext &ctx = metal_context();
+  if (!ctx.has_device())
+    throw std::runtime_error("Metal device unavailable");
   id<MTLCommandQueue> queue = nil;
   id<MTLCommandBuffer> cmd = nil;
   id<MTLBlitCommandEncoder> blit = ctx.acquire_blit_encoder(queue, cmd);
   if (!blit)
     throw std::runtime_error("Metal device unavailable");
-  id<MTLBuffer> dst = (__bridge id<MTLBuffer>)dstBuf;
-  id<MTLBuffer> src = (__bridge id<MTLBuffer>)(const_cast<void *>(srcBuf));
+  id<MTLBuffer> dst = dstBuf;
+  id<MTLBuffer> src = srcBuf;
   [blit copyFromBuffer:src
            sourceOffset:0
                toBuffer:dst
@@ -58,11 +106,12 @@ void metal_copy_buffers(void *dstBuf, const void *srcBuf, std::size_t bytes) {
   ctx.return_command_queue(queue);
 }
 
-void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes) {
+void metal_copy_cpu_to_metal(MTLBufferRef dstBuf, const void *src,
+                             std::size_t bytes) {
   MetalContext &ctx = metal_context();
-  if (!ctx.device())
+  if (!ctx.has_device())
     throw std::runtime_error("Metal device unavailable");
-  id<MTLBuffer> dst = (__bridge id<MTLBuffer>)dstBuf;
+  id<MTLBuffer> dst = dstBuf;
   id<MTLBuffer> tmp =
       [ctx.device() newBufferWithBytes:src
                                 length:bytes
@@ -86,11 +135,12 @@ void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes) {
   [tmp release];
 }
 
-void metal_copy_metal_to_cpu(void *dst, const void *srcBuf, std::size_t bytes) {
+void metal_copy_metal_to_cpu(void *dst, MTLBufferRef srcBuf,
+                             std::size_t bytes) {
   MetalContext &ctx = metal_context();
-  if (!ctx.device())
+  if (!ctx.has_device())
     throw std::runtime_error("Metal device unavailable");
-  id<MTLBuffer> src = (__bridge id<MTLBuffer>)(const_cast<void *>(srcBuf));
+  id<MTLBuffer> src = srcBuf;
   id<MTLBuffer> tmp =
       [ctx.device() newBufferWithBytesNoCopy:dst
                                       length:bytes

--- a/metal-tensor/metal/runtime/runtime_cpu.cpp
+++ b/metal-tensor/metal/runtime/runtime_cpu.cpp
@@ -8,6 +8,28 @@
 #include <unordered_map>
 
 namespace orchard::runtime {
+MetalContext::MetalContext() = default;
+
+MTLDeviceRef MetalContext::device() const { return nullptr; }
+
+bool MetalContext::has_device() const { return false; }
+
+MTLCommandQueueRef MetalContext::acquire_command_queue() { return nullptr; }
+
+void MetalContext::return_command_queue(MTLCommandQueueRef) {}
+
+MTLBlitCommandEncoderRef
+MetalContext::acquire_blit_encoder(MTLCommandQueueRef &queue,
+                                   MTLCommandBufferRef &cmdBuf) {
+  queue = nullptr;
+  cmdBuf = nullptr;
+  return nullptr;
+}
+
+MetalContext &metal_context() {
+  thread_local MetalContext ctx;
+  return ctx;
+}
 
 using ContextFactory = void *(*)();
 
@@ -38,15 +60,15 @@ void register_runtime_devices() {
   register_device("cpu", []() -> void * { return &cpu_context(); });
 }
 
-void metal_copy_buffers(void *, const void *, std::size_t) {
+void metal_copy_buffers(MTLBufferRef, MTLBufferRef, std::size_t) {
   throw std::runtime_error("Metal device unavailable");
 }
 
-void metal_copy_cpu_to_metal(void *, const void *, std::size_t) {
+void metal_copy_cpu_to_metal(MTLBufferRef, const void *, std::size_t) {
   throw std::runtime_error("Metal device unavailable");
 }
 
-void metal_copy_metal_to_cpu(void *, const void *, std::size_t) {
+void metal_copy_metal_to_cpu(void *, MTLBufferRef, std::size_t) {
   throw std::runtime_error("Metal device unavailable");
 }
 

--- a/metal-tensor/tests/fallback_tests.cpp
+++ b/metal-tensor/tests/fallback_tests.cpp
@@ -28,14 +28,18 @@ TEST(FallbackTest, AccumulateFallsBackToCpu) {
   EXPECT_FLOAT_EQ(grad[1], 1.0f);
 }
 TEST(FallbackTest, CopyBuffersThrowsWithoutDevice) {
+  if (orchard::runtime::metal_context().has_device())
+    GTEST_SKIP() << "Metal device present; skipping CPU fallback test.";
   std::array<std::int64_t, 8> shape{1, 1, 1, 1, 1, 1, 1, 1};
   Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
   Tensor b = Tensor::empty(shape, DType::f32, Device::cpu);
   EXPECT_THROW(
       {
         try {
-          orchard::runtime::metal_copy_buffers(a.data_ptr(), b.data_ptr(),
-                                               sizeof(float));
+          orchard::runtime::metal_copy_buffers(
+              static_cast<orchard::runtime::MTLBufferRef>(a.data_ptr()),
+              static_cast<orchard::runtime::MTLBufferRef>(b.data_ptr()),
+              sizeof(float));
         } catch (const std::runtime_error &e) {
           EXPECT_STREQ("Metal device unavailable", e.what());
           throw;


### PR DESCRIPTION
## Summary
- guard CopyBuffersThrowsWithoutDevice fallback test when a Metal device is present
- require MTLBufferRef parameters for Metal copy helpers and check availability before dereferencing
- expose cross-platform has_device and MTLBufferRef in MetalContext and adapt tensor copies
- centralize MetalContext construction so device checks are shared across translation units

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_68a0cedc5b78832e8098ce33acadf49b