### PR TITLE
Strengthen Metal copy helpers

### DIFF
--- a/metal-tensor/metal/core/tensor/Tensor.cpp
+++ b/metal-tensor/metal/core/tensor/Tensor.cpp
@@ -380,16 +380,23 @@ Tensor Tensor::to(Device dev) const {
       else if (impl_->device == Device::cpu && dev == Device::mps) {
         if (!aligned64(src.data_ptr()))
           return Tensor{};
-        orchard::runtime::metal_copy_cpu_to_metal(t.impl_->storage->data,
-                                                  src.data_ptr(), bytes);
+        orchard::runtime::metal_copy_cpu_to_metal(
+            static_cast<orchard::runtime::MTLBufferRef>(t.impl_->storage->data),
+            src.data_ptr(), bytes);
       } else if (impl_->device == Device::mps && dev == Device::cpu) {
         if (!aligned64(t.data_ptr()))
           return Tensor{};
         orchard::runtime::metal_copy_metal_to_cpu(
-            t.data_ptr(), src.impl_->storage->data, bytes);
+            t.data_ptr(),
+            static_cast<orchard::runtime::MTLBufferRef>(
+                src.impl_->storage->data),
+            bytes);
       } else if (impl_->device == Device::mps && dev == Device::mps) {
-        orchard::runtime::metal_copy_buffers(t.impl_->storage->data,
-                                             src.impl_->storage->data, bytes);
+        orchard::runtime::metal_copy_buffers(
+            static_cast<orchard::runtime::MTLBufferRef>(t.impl_->storage->data),
+            static_cast<orchard::runtime::MTLBufferRef>(
+                src.impl_->storage->data),
+            bytes);
       } else {
         std::memcpy(t.data_ptr(), src.data_ptr(), bytes);
       }

--- a/metal-tensor/metal/runtime/MetalContext.h
+++ b/metal-tensor/metal/runtime/MetalContext.h
@@ -8,20 +8,22 @@
 
 #include <vector>
 
+namespace orchard::runtime {
+
 #if defined(__APPLE__) && defined(__OBJC__)
 #include <Metal/Metal.h>
 using MTLDeviceRef = id<MTLDevice>;
 using MTLCommandQueueRef = id<MTLCommandQueue>;
 using MTLCommandBufferRef = id<MTLCommandBuffer>;
 using MTLBlitCommandEncoderRef = id<MTLBlitCommandEncoder>;
+using MTLBufferRef = id<MTLBuffer>;
 #else
 using MTLDeviceRef = void *;
 using MTLCommandQueueRef = void *;
 using MTLCommandBufferRef = void *;
 using MTLBlitCommandEncoderRef = void *;
+using MTLBufferRef = void *;
 #endif
-
-namespace orchard::runtime {
 
 class MetalContext {
 public:
@@ -30,8 +32,10 @@ public:
 #if defined(__APPLE__) && defined(__OBJC__)
   /// Returns the underlying MTLDevice.
   MTLDeviceRef device() const { return device_missing_ ? nil : device_; }
-  bool has_device() const { return !device_missing_; }
+#else
+  MTLDeviceRef device() const { return nullptr; }
 #endif
+  bool has_device() const { return !device_missing_; }
 
   /// Acquire a command queue for the current thread.
   MTLCommandQueueRef acquire_command_queue();
@@ -48,11 +52,13 @@ public:
 private:
 #if defined(__APPLE__) && defined(__OBJC__)
   MTLDeviceRef device_ = nil;
-  bool device_missing_ = false;
-  std::vector<MTLCommandQueueRef> queue_pool_;
 #else
   [[maybe_unused]] MTLDeviceRef device_ = nullptr;
-  [[maybe_unused]] bool device_missing_ = true;
+#endif
+  bool device_missing_ = true;
+#if defined(__APPLE__) && defined(__OBJC__)
+  std::vector<MTLCommandQueueRef> queue_pool_;
+#else
   [[maybe_unused]] std::vector<MTLCommandQueueRef> queue_pool_;
 #endif
 };
@@ -70,7 +76,7 @@ inline orchard::runtime::MetalContext::MetalContext() {
 #endif
 }
 
-inline MTLCommandQueueRef
+inline orchard::runtime::MTLCommandQueueRef
 orchard::runtime::MetalContext::acquire_command_queue() {
 #if defined(__APPLE__) && defined(__OBJC__)
   if (device_missing_)
@@ -86,8 +92,8 @@ orchard::runtime::MetalContext::acquire_command_queue() {
 #endif
 }
 
-inline void
-orchard::runtime::MetalContext::return_command_queue(MTLCommandQueueRef queue) {
+inline void orchard::runtime::MetalContext::return_command_queue(
+    orchard::runtime::MTLCommandQueueRef queue) {
 #if defined(__APPLE__) && defined(__OBJC__)
   if (!device_missing_ && queue)
     queue_pool_.push_back(queue);
@@ -96,9 +102,10 @@ orchard::runtime::MetalContext::return_command_queue(MTLCommandQueueRef queue) {
 #endif
 }
 
-inline MTLBlitCommandEncoderRef
+inline orchard::runtime::MTLBlitCommandEncoderRef
 orchard::runtime::MetalContext::acquire_blit_encoder(
-    MTLCommandQueueRef &queue, MTLCommandBufferRef &cmdBuf) {
+    orchard::runtime::MTLCommandQueueRef &queue,
+    orchard::runtime::MTLCommandBufferRef &cmdBuf) {
 #if defined(__APPLE__) && defined(__OBJC__)
   if (device_missing_) {
     queue = nil;
@@ -113,9 +120,4 @@ orchard::runtime::MetalContext::acquire_blit_encoder(
   (void)cmdBuf;
   return nullptr;
 #endif
-}
-
-inline orchard::runtime::MetalContext &orchard::runtime::metal_context() {
-  thread_local MetalContext ctx;
-  return ctx;
 }

--- a/metal-tensor/metal/runtime/Runtime.h
+++ b/metal-tensor/metal/runtime/Runtime.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include "runtime/MetalContext.h"
 #include <cstddef>
 
 namespace orchard::runtime {
 
-void metal_copy_buffers(void *dstBuf, const void *srcBuf, std::size_t bytes);
-void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes);
-void metal_copy_metal_to_cpu(void *dst, const void *srcBuf, std::size_t bytes);
+void metal_copy_buffers(MTLBufferRef dstBuf, MTLBufferRef srcBuf,
+                        std::size_t bytes);
+void metal_copy_cpu_to_metal(MTLBufferRef dstBuf, const void *src,
+                             std::size_t bytes);
+void metal_copy_metal_to_cpu(void *dst, MTLBufferRef srcBuf, std::size_t bytes);
 
 } // namespace orchard::runtime

--- a/metal-tensor/metal/runtime/runtime.mm
+++ b/metal-tensor/metal/runtime/runtime.mm
@@ -10,6 +10,11 @@ namespace orchard::runtime {
 
 using ContextFactory = void *(*)();
 
+MetalContext &metal_context() {
+  thread_local MetalContext ctx;
+  return ctx;
+}
+
 namespace {
 
 // Simple registry mapping device names to context factories.
@@ -38,15 +43,18 @@ void register_runtime_devices() {
 }
 
 #ifdef __APPLE__
-void metal_copy_buffers(void *dstBuf, const void *srcBuf, std::size_t bytes) {
+void metal_copy_buffers(MTLBufferRef dstBuf, MTLBufferRef srcBuf,
+                        std::size_t bytes) {
   MetalContext &ctx = metal_context();
+  if (!ctx.has_device())
+    throw std::runtime_error("Metal device unavailable");
   id<MTLCommandQueue> queue = nil;
   id<MTLCommandBuffer> cmd = nil;
   id<MTLBlitCommandEncoder> blit = ctx.acquire_blit_encoder(queue, cmd);
   if (!blit)
     throw std::runtime_error("Metal device unavailable");
-  id<MTLBuffer> dst = (__bridge id<MTLBuffer>)dstBuf;
-  id<MTLBuffer> src = (__bridge id<MTLBuffer>)(const_cast<void *>(srcBuf));
+  id<MTLBuffer> dst = dstBuf;
+  id<MTLBuffer> src = srcBuf;
   [blit copyFromBuffer:src
            sourceOffset:0
                toBuffer:dst
@@ -58,11 +66,12 @@ void metal_copy_buffers(void *dstBuf, const void *srcBuf, std::size_t bytes) {
   ctx.return_command_queue(queue);
 }
 
-void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes) {
+void metal_copy_cpu_to_metal(MTLBufferRef dstBuf, const void *src,
+                             std::size_t bytes) {
   MetalContext &ctx = metal_context();
-  if (!ctx.device())
+  if (!ctx.has_device())
     throw std::runtime_error("Metal device unavailable");
-  id<MTLBuffer> dst = (__bridge id<MTLBuffer>)dstBuf;
+  id<MTLBuffer> dst = dstBuf;
   id<MTLBuffer> tmp =
       [ctx.device() newBufferWithBytes:src
                                 length:bytes
@@ -86,11 +95,12 @@ void metal_copy_cpu_to_metal(void *dstBuf, const void *src, std::size_t bytes) {
   [tmp release];
 }
 
-void metal_copy_metal_to_cpu(void *dst, const void *srcBuf, std::size_t bytes) {
+void metal_copy_metal_to_cpu(void *dst, MTLBufferRef srcBuf,
+                             std::size_t bytes) {
   MetalContext &ctx = metal_context();
-  if (!ctx.device())
+  if (!ctx.has_device())
     throw std::runtime_error("Metal device unavailable");
-  id<MTLBuffer> src = (__bridge id<MTLBuffer>)(const_cast<void *>(srcBuf));
+  id<MTLBuffer> src = srcBuf;
   id<MTLBuffer> tmp =
       [ctx.device() newBufferWithBytesNoCopy:dst
                                       length:bytes

--- a/metal-tensor/metal/runtime/runtime_cpu.cpp
+++ b/metal-tensor/metal/runtime/runtime_cpu.cpp
@@ -11,6 +11,11 @@ namespace orchard::runtime {
 
 using ContextFactory = void *(*)();
 
+MetalContext &metal_context() {
+  thread_local MetalContext ctx;
+  return ctx;
+}
+
 namespace {
 
 // Simple registry mapping device names to context factories.
@@ -38,15 +43,15 @@ void register_runtime_devices() {
   register_device("cpu", []() -> void * { return &cpu_context(); });
 }
 
-void metal_copy_buffers(void *, const void *, std::size_t) {
+void metal_copy_buffers(MTLBufferRef, MTLBufferRef, std::size_t) {
   throw std::runtime_error("Metal device unavailable");
 }
 
-void metal_copy_cpu_to_metal(void *, const void *, std::size_t) {
+void metal_copy_cpu_to_metal(MTLBufferRef, const void *, std::size_t) {
   throw std::runtime_error("Metal device unavailable");
 }
 
-void metal_copy_metal_to_cpu(void *, const void *, std::size_t) {
+void metal_copy_metal_to_cpu(void *, MTLBufferRef, std::size_t) {
   throw std::runtime_error("Metal device unavailable");
 }
 

--- a/metal-tensor/tests/fallback_tests.cpp
+++ b/metal-tensor/tests/fallback_tests.cpp
@@ -28,14 +28,18 @@ TEST(FallbackTest, AccumulateFallsBackToCpu) {
   EXPECT_FLOAT_EQ(grad[1], 1.0f);
 }
 TEST(FallbackTest, CopyBuffersThrowsWithoutDevice) {
+  if (orchard::runtime::metal_context().has_device())
+    GTEST_SKIP() << "Metal device present; skipping CPU fallback test.";
   std::array<std::int64_t, 8> shape{1, 1, 1, 1, 1, 1, 1, 1};
   Tensor a = Tensor::empty(shape, DType::f32, Device::cpu);
   Tensor b = Tensor::empty(shape, DType::f32, Device::cpu);
   EXPECT_THROW(
       {
         try {
-          orchard::runtime::metal_copy_buffers(a.data_ptr(), b.data_ptr(),
-                                               sizeof(float));
+          orchard::runtime::metal_copy_buffers(
+              static_cast<orchard::runtime::MTLBufferRef>(a.data_ptr()),
+              static_cast<orchard::runtime::MTLBufferRef>(b.data_ptr()),
+              sizeof(float));
         } catch (const std::runtime_error &e) {
           EXPECT_STREQ("Metal device unavailable", e.what());
           throw;


### PR DESCRIPTION
## Summary
- guard CopyBuffersThrowsWithoutDevice fallback test when a Metal device is present
- require MTLBufferRef parameters for Metal copy helpers and check availability before dereferencing
- expose cross-platform has_device and MTLBufferRef in MetalContext and adapt tensor copies
- share MetalContext across translation units so has_device reflects real hardware

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target check`


------
https://chatgpt.com/codex/tasks/task_e_68a0cedc5b78832e8098ce33acadf49b